### PR TITLE
Add one tank example to ci/cd runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     name: Run Examples
     strategy:
       matrix:
-        example: ["boiler", "failure_time_prediction", "linear_data"]
+        example: ["boiler", "failure_time_prediction", "linear_data", "one_tank"]
     runs-on: self-hosted
     env:
       CUDA_VISIBLE_DEVICES: ""


### PR DESCRIPTION
This MR:
- Adds the one tank example to the ci runs.
 
This example uses both scikit-learn and pytorch/lightning, so runtime in the pipeline might be an issue? However, since it does not rely on dvc, the results might be more consistent and we could use it as a subsitutaion for failure time prediction?