### PR TITLE
Add github link to documentation

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,7 @@
 site_name: Flowcean
+repo_url: https://github.com/flowcean/flowcean
+repo_name: flowcean/flowcean
+
 theme:
   name: "material"
   features:
@@ -25,6 +28,8 @@ theme:
       toggle:
         icon: material/weather-night
         name: Switch to system preference
+  icon:
+    repo: fontawesome/brands/github
 
 plugins:
   - mkdocstrings:


### PR DESCRIPTION
This MR:
- Adds a link to this repository at the documentation.

The link looks like this
![grafik](https://github.com/flowcean/flowcean/assets/167854903/b4c0f6e7-5c49-4f4f-9918-d7f3fb4115c7)

We might want to discuss the text (currently "flowcean/flowcean") and the icon. For a list of possible choices have a look here https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#repository-icon.

Closes #46.