### PR TITLE
Add new ALP sim data

### DIFF
--- a/examples/automatic_lashing_platform/.gitignore
+++ b/examples/automatic_lashing_platform/.gitignore
@@ -1,2 +1,1 @@
 models/
-/data

--- a/examples/automatic_lashing_platform/.gitignore
+++ b/examples/automatic_lashing_platform/.gitignore
@@ -1,1 +1,2 @@
 models/
+/data

--- a/examples/automatic_lashing_platform/data.dvc
+++ b/examples/automatic_lashing_platform/data.dvc
@@ -1,6 +1,0 @@
-outs:
-- md5: 33ba2b2790ff5db25e7c3752eef4303b.dir
-  size: 111345254
-  nfiles: 1873
-  hash: md5
-  path: data

--- a/examples/automatic_lashing_platform/data.dvc
+++ b/examples/automatic_lashing_platform/data.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 77976d4feb80c1c2f11641a06c2d47cb.dir
+  size: 1931760487
+  nfiles: 33476
+  hash: md5
+  path: data


### PR DESCRIPTION
This PR:
- Remvoes the old ALP data from DVC
- Add a new batch of simulation data from the ALP to the DVC (~16.000 simulation runs)