### PR TITLE
Constrain numpy for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 
 dependencies = [
-  "numpy",
+  "numpy<2",
   "polars",
   "ruamel.yaml",
   "typing-extensions",


### PR DESCRIPTION
This PR:
- Constrains the numpy version to pre-2.0 versions for now

Closes #105.