### PR TITLE
Add rechunk transform

### DIFF
--- a/src/flowcean/transforms/rechunk.py
+++ b/src/flowcean/transforms/rechunk.py
@@ -1,0 +1,24 @@
+from typing import override
+
+import polars as pl
+
+from flowcean.core.transform import Transform
+
+
+class Rechunk(Transform):
+    """Rechunks a dataframe.
+
+    Rearranges a dataframe so that it resides in a contiguous block of memory.
+    This improves the performance of any subsequent transform performed on the
+    rechunked dataframe. However, this operation can be costly depending on the
+    size of the dataframe, so it should be used with care and only when deemed
+    necessary.
+    """
+
+    def __init__(self) -> None:
+        """Initializes the Rechunk transform."""
+        super().__init__()
+
+    @override
+    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+        return data.rechunk()

--- a/tests/transforms/test_rechunk.py
+++ b/tests/transforms/test_rechunk.py
@@ -1,0 +1,30 @@
+import unittest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+from flowcean.transforms.rechunk import Rechunk
+
+
+class RechunkTransform(unittest.TestCase):
+    def test_rechunk(self) -> None:
+        transform = Rechunk()
+
+        data_frame = pl.DataFrame(
+            [
+                {"a": 1, "b": 2, "c": 3},
+                {"a": 4, "b": 5, "c": 6},
+                {"a": 7, "b": 8, "c": 9},
+                {"a": 10, "b": 11, "c": 12},
+            ],
+        )
+        transformed_data = transform.transform(data_frame)
+
+        assert_frame_equal(
+            transformed_data,
+            data_frame,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR:
- Adds a `Rechunk` transform. Even though this transform is a really slim wrapper around `df.rechunk()` however I still think it's worth to create a dedicated transform for this so we have the functionality documented for cps developers.

Closes #108.