### PR TITLE
Add `to_time_series` method

### DIFF
--- a/tests/core/test_to_time_series.py
+++ b/tests/core/test_to_time_series.py
@@ -1,0 +1,50 @@
+import unittest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+from flowcean.environments.dataset import Dataset
+
+
+class TestToTimeSeries(unittest.TestCase):
+    def test_to_time_series_single_time_feature(self) -> None:
+        dataset = Dataset(
+            pl.DataFrame(
+                {
+                    "time_feature": [0, 1, 2, 3],
+                    "feature_a": [42, 43, 44, 45],
+                    "feature_b": [3, 2, 1, 0],
+                }
+            )
+        )
+
+        time_series_dataset = dataset.to_time_series("time_feature")
+
+        assert_frame_equal(
+            time_series_dataset.get_data(),
+            pl.DataFrame(
+                {
+                    "feature_a": [
+                        [
+                            {"time": 0, "value": 42},
+                            {"time": 1, "value": 43},
+                            {"time": 2, "value": 44},
+                            {"time": 3, "value": 45},
+                        ],
+                    ],
+                    "feature_b": [
+                        [
+                            {"time": 0, "value": 3},
+                            {"time": 1, "value": 2},
+                            {"time": 2, "value": 1},
+                            {"time": 3, "value": 0},
+                        ],
+                    ],
+                },
+            ),
+            check_column_order=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR:
- Adds a `to_time_series` method to `OfflineEnvironment` to convert one to a single entry in a time series envrionment.

For now this method is directly attached to the `OfflineEnvironment`. This however adds "production" code to the base class. We can / should discuss if and where we could move such a method instead.