### PR TITLE
Add Resample transform

### DIFF
--- a/src/flowcean/transforms/__init__.py
+++ b/src/flowcean/transforms/__init__.py
@@ -4,6 +4,8 @@ __all__ = [
     "FeatureLengthVaryError",
     "NoTimeSeriesFeatureError",
     "MatchSamplingRate",
+    "Rechunk",
+    "Resample",
     "Select",
     "SlidingWindow",
     "Standardize",
@@ -12,6 +14,8 @@ __all__ = [
 from .explode import Explode
 from .flatten import FeatureLengthVaryError, Flatten, NoTimeSeriesFeatureError
 from .match_sampling_rate import MatchSamplingRate
+from .rechunk import Rechunk
+from .resample import Resample
 from .select import Select
 from .sliding_window import SlidingWindow
 from .standardize import Standardize

--- a/src/flowcean/transforms/resample.py
+++ b/src/flowcean/transforms/resample.py
@@ -1,0 +1,78 @@
+import logging
+from typing import cast, override
+
+import numpy as np
+import polars as pl
+
+from flowcean.core import Transform
+
+logger = logging.getLogger(__name__)
+
+
+class Resample(Transform):
+    """Resample time series features to a given sampling rate."""
+
+    def __init__(self, sampling_rate: float | dict[str, float]) -> None:
+        """Initializes the Resample transform.
+
+        Args:
+            sampling_rate: Target sampling rate for time series features. If a
+            float is provided, all possible time series features will be
+            resampled. Alternatively, a dictionary can be provided where the
+            key is the feature and the value is the target sample rate.
+        """
+        self.sampling_rate = sampling_rate
+
+    @override
+    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+        sampling_mapping = (
+            {
+                column_name: self.sampling_rate
+                for column_name in data.columns
+                if is_timeseries_column(data, column_name)
+            }
+            if isinstance(self.sampling_rate, float)
+            else cast(dict[str, float], self.sampling_rate)
+        )
+
+        for feature, dt in sampling_mapping.items():
+            # Select the time and the value vector
+            time = data.select(
+                pl.col(feature).list.eval(pl.first().struct.field("time"))
+            ).to_numpy()
+
+            value = data.select(
+                pl.col(feature).list.eval(pl.first().struct.field("value"))
+            ).to_numpy()
+
+            # Create the new time vector
+            t_interp = np.arange(time[0], time[-1], dt)
+
+            # Interpolate the value vector to match the new time vector
+            value_interp = np.interp(t_interp, time, value)
+
+            # Build a new feature from the interpolate data.
+            # Because the new column has also the name "feature", the old
+            # feature will be overriden
+            data = data.with_columns(
+                pl.DataFrame({"time": t_interp, "value": value_interp})
+                .to_struct()
+                .implode()
+                .alias(feature)
+            )
+
+        return data
+
+
+def is_timeseries_column(df: pl.DataFrame, column_name: str) -> bool:
+    data_type = df.select(column_name).dtypes[0]
+
+    if data_type.base_type() != pl.List:
+        return False
+
+    inner_type: pl.DataType = cast(pl.DataType, cast(pl.List, data_type).inner)
+    if inner_type.base_type() != pl.Struct:
+        return False
+
+    field_names = [field.name for field in cast(pl.Struct, inner_type).fields]
+    return "time" in field_names and "value" in field_names

--- a/tests/transforms/test_resample.py
+++ b/tests/transforms/test_resample.py
@@ -45,34 +45,34 @@ class ResampleTransform(unittest.TestCase):
                     "feature_a": [
                         [
                             {
-                                "time": 0,
-                                "value": 1,
+                                "time": 0.0,
+                                "value": 1.0,
                             },
                             {
-                                "time": 1,
+                                "time": 1.0,
                                 "value": 1.5,
                             },
                             {
-                                "time": 2,
-                                "value": 2,
+                                "time": 2.0,
+                                "value": 2.0,
                             },
                         ],
                         [
                             {
-                                "time": 0,
-                                "value": 0,
+                                "time": 0.0,
+                                "value": 0.0,
                             },
                             {
-                                "time": 1,
-                                "value": 1,
+                                "time": 1.0,
+                                "value": 1.0,
                             },
                             {
-                                "time": 2,
-                                "value": 2,
+                                "time": 2.0,
+                                "value": 2.0,
                             },
                             {
-                                "time": 3,
-                                "value": 3,
+                                "time": 3.0,
+                                "value": 3.0,
                             },
                         ],
                     ],

--- a/tests/transforms/test_resample.py
+++ b/tests/transforms/test_resample.py
@@ -1,0 +1,86 @@
+import unittest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+from flowcean.transforms import Resample
+
+
+class ResampleTransform(unittest.TestCase):
+    def test_simple(self) -> None:
+        transform = Resample(1.0)
+        data_frame = pl.DataFrame(
+            {
+                "feature_a": [
+                    [
+                        {
+                            "time": 0,
+                            "value": 1,
+                        },
+                        {
+                            "time": 2,
+                            "value": 2,
+                        },
+                    ],
+                    [
+                        {
+                            "time": 0,
+                            "value": 0,
+                        },
+                        {
+                            "time": 3,
+                            "value": 3,
+                        },
+                    ],
+                ],
+                "scalar": [1, 2],
+            }
+        )
+        transformed_data = transform.transform(data_frame)
+
+        assert_frame_equal(
+            transformed_data,
+            pl.DataFrame(
+                {
+                    "feature_a": [
+                        [
+                            {
+                                "time": 0,
+                                "value": 1,
+                            },
+                            {
+                                "time": 1,
+                                "value": 1.5,
+                            },
+                            {
+                                "time": 2,
+                                "value": 2,
+                            },
+                        ],
+                        [
+                            {
+                                "time": 0,
+                                "value": 0,
+                            },
+                            {
+                                "time": 1,
+                                "value": 1,
+                            },
+                            {
+                                "time": 2,
+                                "value": 2,
+                            },
+                            {
+                                "time": 3,
+                                "value": 3,
+                            },
+                        ],
+                    ],
+                    "scalar": [1, 2],
+                }
+            ),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/transforms/test_resample.py
+++ b/tests/transforms/test_resample.py
@@ -81,6 +81,80 @@ class ResampleTransform(unittest.TestCase):
             ),
         )
 
+    def test_different_sample_rates(self) -> None:
+        transform = Resample({"feature_a": 1.0, "feature_b": 2.0})
+        data_frame = pl.DataFrame(
+            {
+                "feature_a": [
+                    [
+                        {
+                            "time": 0,
+                            "value": 1,
+                        },
+                        {
+                            "time": 2,
+                            "value": 2,
+                        },
+                    ],
+                ],
+                "feature_b": [
+                    [
+                        {
+                            "time": 0,
+                            "value": 0,
+                        },
+                        {
+                            "time": 1,
+                            "value": 1,
+                        },
+                        {
+                            "time": 2,
+                            "value": 2,
+                        },
+                    ],
+                ],
+                "scalar": [42],
+            }
+        )
+        transformed_data = transform.transform(data_frame)
+
+        assert_frame_equal(
+            transformed_data,
+            pl.DataFrame(
+                {
+                    "feature_a": [
+                        [
+                            {
+                                "time": 0.0,
+                                "value": 1.0,
+                            },
+                            {
+                                "time": 1.0,
+                                "value": 1.5,
+                            },
+                            {
+                                "time": 2.0,
+                                "value": 2.0,
+                            },
+                        ],
+                    ],
+                    "feature_b": [
+                        [
+                            {
+                                "time": 0.0,
+                                "value": 0.0,
+                            },
+                            {
+                                "time": 2.0,
+                                "value": 2.0,
+                            },
+                        ],
+                    ],
+                    "scalar": [42],
+                }
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR:
- Adds a new implementation of a `Resample` transform to change the sampling rate of time series features.

Probably superseeds #23 as this uses the new time series format.

The implementation could possible still be improved quite a bit. As I use interpolation methods from scipy there is probably no way around moving the data from polars to python and back. @schmidma maybe you have another clever idea how to optimize it further / make it more polars.