### PR TITLE
Add workaround for json loader

### DIFF
--- a/src/flowcean/environments/json.py
+++ b/src/flowcean/environments/json.py
@@ -19,7 +19,15 @@ class JsonDataLoader(OfflineEnvironment):
     def load(self) -> Self:
         with self.path.open() as file:
             json_content = json.load(file)
-        self.data = pl.DataFrame(json_content)
+
+        # Check if any of the entries in the dict is *not* a list and treat the
+        # whole dict as a single entry in that case
+        if isinstance(json_content, dict) and any(
+            not isinstance(value, list) for value in json_content.values()
+        ):
+            self.data = pl.DataFrame([json_content])
+        else:
+            self.data = pl.DataFrame(json_content)
         return self
 
     @override


### PR DESCRIPTION
This PR:
- Adds a check for the `JsonDataloader` to infer the right data schema and not implicitly repeat data

Without this PR a json file of the format
```json
{
  "feature_a": 5,
  "feature_b": [1,2]
}
```
would be loaded as

feature_a | feature_b
----------|-----------
 5            | 1
 5            | 2

which is most likely not what the user intended.
With this PR, the loaded data will be

feature_a | feature_b
----------|-----------
 5            | [1, 2]

to achieve the previous results the input json should be

```json
{
  "feature_a": [5,5],
  "feature_b": [1,2]
}
```

