### PR TITLE
Add real ALP meassurement data

### DIFF
--- a/examples/automatic_lashing_platform/.gitignore
+++ b/examples/automatic_lashing_platform/.gitignore
@@ -1,2 +1,3 @@
 models/
 /data
+/real_data

--- a/examples/automatic_lashing_platform/real_data.dvc
+++ b/examples/automatic_lashing_platform/real_data.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: a7e944094600419c050e2efbb97e4f7f.dir
+  size: 416930
+  nfiles: 46
+  hash: md5
+  path: real_data


### PR DESCRIPTION
This PR:
- Adds a first batch of real meassurement data from the ALP. The data *should* have the same format then the simulation data but is limited to six second recordings.

We shall discuss if this data remains in the repo when / if the storage becomes public.