### PR TITLE
Support lazy frames in transforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
 
 dependencies = [
   "numpy<2",
-  "polars",
+  "polars>=1.4",
   "ruamel.yaml",
   "typing-extensions",
   "tqdm",

--- a/src/flowcean/core/environment/offline.py
+++ b/src/flowcean/core/environment/offline.py
@@ -85,7 +85,7 @@ class OfflineEnvironment(Environment):
         if isinstance(time_feature, str):
             time_feature = {
                 feature_name: time_feature
-                for feature_name in data.columns
+                for feature_name in data.collect_schema().names()
                 if feature_name != time_feature
             }
 

--- a/src/flowcean/core/environment/transformed.py
+++ b/src/flowcean/core/environment/transformed.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Generic, Self, TypeVar, override
 
+import polars as pl
+
 from .base import Environment
 from .incremental import IncrementalEnvironment
 from .offline import OfflineEnvironment
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-
-    import polars as pl
 
     from flowcean.core import Transform
 
@@ -65,8 +65,8 @@ class TransformedEnvironment(
     def get_data(
         self: TransformedEnvironment[T_OfflineEnvironment],
     ) -> pl.DataFrame:
-        data = self.environment.get_data()
-        return self.transform.transform(data)
+        data = self.transform.transform(self.environment.get_data())
+        return data if isinstance(data, pl.DataFrame) else data.collect()
 
     @override
     def __iter__(

--- a/src/flowcean/core/model.py
+++ b/src/flowcean/core/model.py
@@ -51,7 +51,11 @@ class ModelWithTransform(Model):
         input_features: pl.DataFrame,
     ) -> pl.DataFrame:
         transformed = self.transform.transform(input_features)
-        return self.model.predict(transformed)
+        return self.model.predict(
+            transformed
+            if isinstance(transformed, pl.DataFrame)
+            else transformed.collect()
+        )
 
     @override
     def save(self, path: Path) -> None:

--- a/src/flowcean/core/transform.py
+++ b/src/flowcean/core/transform.py
@@ -64,7 +64,9 @@ class Transform(ABC):
     """Base class for all transforms."""
 
     @abstractmethod
-    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
         """Transform the data.
 
         Args:

--- a/src/flowcean/strategies/incremental.py
+++ b/src/flowcean/strategies/incremental.py
@@ -1,3 +1,5 @@
+import polars as pl
+
 from flowcean.core import (
     IncrementalEnvironment,
     Model,
@@ -38,10 +40,22 @@ def learn_incremental(
 
         if input_transform is not None:
             if isinstance(input_transform, UnsupervisedIncrementalLearner):
+                input_features = (
+                    input_features
+                    if isinstance(input_features, pl.DataFrame)
+                    else input_features.collect()
+                )
                 input_transform.fit_incremental(input_features)
             input_features = input_transform.transform(input_features)
 
-        model = learner.learn_incremental(input_features, output_features)
+        model = learner.learn_incremental(
+            input_features
+            if isinstance(input_features, pl.DataFrame)
+            else input_features.collect(),
+            output_features
+            if isinstance(output_features, pl.DataFrame)
+            else output_features.collect(),
+        )
 
     if model is None:
         message = "No data found in environment."

--- a/src/flowcean/strategies/offline.py
+++ b/src/flowcean/strategies/offline.py
@@ -1,5 +1,7 @@
 import logging
 
+import polars as pl
+
 from flowcean.core.environment.offline import OfflineEnvironment
 from flowcean.core.learner import SupervisedLearner, UnsupervisedLearner
 from flowcean.core.metric import OfflineMetric
@@ -45,7 +47,14 @@ def learn_offline(
         input_features = input_transform.transform(input_features)
 
     logger.info("Learning model")
-    model = learner.learn(input_features, output_features)
+    model = learner.learn(
+        input_features
+        if isinstance(input_features, pl.DataFrame)
+        else input_features.collect(),
+        output_features
+        if isinstance(output_features, pl.DataFrame)
+        else output_features.collect(),
+    )
 
     if input_transform is not None:
         return ModelWithTransform(model=model, transform=input_transform)

--- a/src/flowcean/transforms/__init__.py
+++ b/src/flowcean/transforms/__init__.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "Collect",
     "Explode",
     "Flatten",
     "FeatureLengthVaryError",
@@ -13,6 +14,7 @@ __all__ = [
     "ToLazy",
 ]
 
+from .collect import Collect
 from .explode import Explode
 from .flatten import FeatureLengthVaryError, Flatten, NoTimeSeriesFeatureError
 from .match_sampling_rate import MatchSamplingRate

--- a/src/flowcean/transforms/__init__.py
+++ b/src/flowcean/transforms/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "SlidingWindow",
     "Standardize",
     "TimeWindow",
+    "ToLazy",
 ]
 
 from .explode import Explode
@@ -21,3 +22,4 @@ from .select import Select
 from .sliding_window import SlidingWindow
 from .standardize import Standardize
 from .time_window import TimeWindow
+from .to_lazy import ToLazy

--- a/src/flowcean/transforms/collect.py
+++ b/src/flowcean/transforms/collect.py
@@ -1,0 +1,26 @@
+import logging
+from typing import override
+
+import polars as pl
+
+from flowcean.core import Transform
+
+logger = logging.getLogger(__name__)
+
+
+class Collect(Transform):
+    """Convert data to a materialized representation.
+
+    Materialize data by performing any queued transform on it. Operations are
+    optimized before execution for improved performance.
+    """
+
+    def __init__(self) -> None:
+        """Initializes the Collect transform."""
+        super().__init__()
+
+    @override
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
+        return data if isinstance(data, pl.DataFrame) else data.collect()

--- a/src/flowcean/transforms/explode.py
+++ b/src/flowcean/transforms/explode.py
@@ -40,6 +40,8 @@ class Explode(Transform):
         self.features = features
 
     @override
-    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
         logger.debug("Exploding timeseries")
         return data.explode(self.features)

--- a/src/flowcean/transforms/flatten.py
+++ b/src/flowcean/transforms/flatten.py
@@ -43,7 +43,9 @@ class Flatten(Transform):
         self.features = features
 
     @override
-    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
         # Loop over the features we want to explode
         feature_names = (
             self.features
@@ -68,6 +70,8 @@ class Flatten(Transform):
                 .list.eval(pl.first().struct.field("value"))
                 .list.len()
             ).unique()
+            if isinstance(row_lengths, pl.LazyFrame):
+                row_lengths = row_lengths.collect()
 
             # Check if all rows have the same length
             if row_lengths.count().item(0, 0) > 1:

--- a/src/flowcean/transforms/flatten.py
+++ b/src/flowcean/transforms/flatten.py
@@ -52,7 +52,7 @@ class Flatten(Transform):
             if self.features is not None
             else [
                 column_name
-                for column_name in data.columns
+                for column_name in data.collect_schema().names()
                 if is_timeseries_feature(data, column_name)
             ]
         )

--- a/src/flowcean/transforms/match_sampling_rate.py
+++ b/src/flowcean/transforms/match_sampling_rate.py
@@ -65,7 +65,11 @@ class MatchSamplingRate(Transform):
         self.reference_timestamps = reference_timestamps
         self.feature_columns_with_timestamps = feature_columns_with_timestamps
 
-    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
+        # Materialize the dataframe if it was lazy
+        data = data if isinstance(data, pl.DataFrame) else data.collect()
         logger.debug("Matching sampling rate of time series.")
 
         for i in range(len(data)):

--- a/src/flowcean/transforms/rechunk.py
+++ b/src/flowcean/transforms/rechunk.py
@@ -12,7 +12,8 @@ class Rechunk(Transform):
     This improves the performance of any subsequent transform performed on the
     rechunked dataframe. However, this operation can be costly depending on the
     size of the dataframe, so it should be used with care and only when deemed
-    necessary.
+    necessary. Also, if the transformed dataframe is lazy, it will be realized,
+    which can reduce the performance gains from lazy execution.
     """
 
     def __init__(self) -> None:
@@ -20,5 +21,11 @@ class Rechunk(Transform):
         super().__init__()
 
     @override
-    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
-        return data.rechunk()
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
+        return (
+            (data if isinstance(data, pl.DataFrame) else data.collect())
+            .rechunk()
+            .lazy()
+        )

--- a/src/flowcean/transforms/resample.py
+++ b/src/flowcean/transforms/resample.py
@@ -38,7 +38,9 @@ class Resample(Transform):
         self.interpolation_method = interpolation_method
 
     @override
-    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
         sampling_mapping = (
             {
                 column_name: self.sampling_rate

--- a/src/flowcean/transforms/resample.py
+++ b/src/flowcean/transforms/resample.py
@@ -44,7 +44,7 @@ class Resample(Transform):
         sampling_mapping = (
             {
                 column_name: self.sampling_rate
-                for column_name in data.columns
+                for column_name in data.collect_schema().names()
                 if is_timeseries_feature(data, column_name)
             }
             if isinstance(self.sampling_rate, float)

--- a/src/flowcean/transforms/select.py
+++ b/src/flowcean/transforms/select.py
@@ -24,6 +24,8 @@ class Select(Transform):
         self.features = features
 
     @override
-    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
         logger.debug("selecting features %s", self.features)
         return data.select(self.features)

--- a/src/flowcean/transforms/sliding_window.py
+++ b/src/flowcean/transforms/sliding_window.py
@@ -39,7 +39,9 @@ class SlidingWindow(Transform):
         self.window_size = window_size
 
     @override
-    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
         return data.select(
             [
                 pl.all()

--- a/src/flowcean/transforms/standardize.py
+++ b/src/flowcean/transforms/standardize.py
@@ -38,7 +38,9 @@ class Standardize(Transform, UnsupervisedLearner):
         self.counts = len(data)
 
     @override
-    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
         if self.mean is None or self.std is None:
             message = "Standardize transform has not been fitted"
             raise RuntimeError(message)

--- a/src/flowcean/transforms/standardize.py
+++ b/src/flowcean/transforms/standardize.py
@@ -49,7 +49,7 @@ class Standardize(Transform, UnsupervisedLearner):
             [
                 (pl.col(c) - (self.mean.get(c) or 0.0))
                 / (self.std.get(c) or 1.0)
-                for c in data.columns
+                for c in data.collect_schema().names()
             ],
         )
 

--- a/src/flowcean/transforms/time_window.py
+++ b/src/flowcean/transforms/time_window.py
@@ -38,7 +38,9 @@ class TimeWindow(Transform):
         self.t_end = time_end
 
     @override
-    def transform(self, data: pl.DataFrame) -> pl.DataFrame:
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
         for feature in (
             self.features
             if self.features is not None

--- a/src/flowcean/transforms/time_window.py
+++ b/src/flowcean/transforms/time_window.py
@@ -44,7 +44,7 @@ class TimeWindow(Transform):
             if self.features is not None
             else [
                 feature
-                for feature in data.columns
+                for feature in data.collect_schema().names()
                 if is_timeseries_feature(data, feature)
             ]
         ):

--- a/src/flowcean/transforms/to_lazy.py
+++ b/src/flowcean/transforms/to_lazy.py
@@ -1,0 +1,30 @@
+import logging
+from typing import override
+
+import polars as pl
+
+from flowcean.core import Transform
+
+logger = logging.getLogger(__name__)
+
+
+class ToLazy(Transform):
+    """Convert data to a lazy representation.
+
+    Convert data into a lazy representation that can speed up subsequent
+    transformations by optimizing them before execution. Most of the flowceans
+    API supports lazy data. If a particular transform does not, use a
+    `Collect' transform to convert the data back to a materialized
+    representation. Multiple calls to this transform will not degrade
+    performance.
+    """
+
+    def __init__(self) -> None:
+        """Initializes the ToLazy transform."""
+        super().__init__()
+
+    @override
+    def transform(
+        self, data: pl.DataFrame | pl.LazyFrame
+    ) -> pl.DataFrame | pl.LazyFrame:
+        return data.lazy()

--- a/src/flowcean/utils/is_time_series.py
+++ b/src/flowcean/utils/is_time_series.py
@@ -6,8 +6,7 @@ import polars as pl
 def is_timeseries_feature(
     df: pl.DataFrame | pl.LazyFrame, column_name: str
 ) -> bool:
-    schema = df.schema if isinstance(df, pl.DataFrame) else df.collect_schema()
-    data_type = schema[column_name]
+    data_type = df.collect_schema()[column_name]
 
     if data_type.base_type() != pl.List:
         return False

--- a/src/flowcean/utils/is_time_series.py
+++ b/src/flowcean/utils/is_time_series.py
@@ -3,8 +3,11 @@ from typing import cast
 import polars as pl
 
 
-def is_timeseries_feature(df: pl.DataFrame, column_name: str) -> bool:
-    data_type = df.select(column_name).dtypes[0]
+def is_timeseries_feature(
+    df: pl.DataFrame | pl.LazyFrame, column_name: str
+) -> bool:
+    schema = df.schema if isinstance(df, pl.DataFrame) else df.collect_schema()
+    data_type = schema[column_name]
 
     if data_type.base_type() != pl.List:
         return False

--- a/tests/transforms/test_collect.py
+++ b/tests/transforms/test_collect.py
@@ -1,0 +1,30 @@
+import unittest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+from flowcean.transforms import Collect
+
+
+class CollectTransform(unittest.TestCase):
+    def test_collect(self) -> None:
+        transform = Collect()
+
+        data_frame = pl.DataFrame(
+            [
+                {"a": 1, "b": 2, "c": 3},
+                {"a": 4, "b": 5, "c": 6},
+                {"a": 7, "b": 8, "c": 9},
+                {"a": 10, "b": 11, "c": 12},
+            ],
+        )
+        transformed_data = transform.transform(data_frame.lazy())
+
+        assert_frame_equal(
+            transformed_data,
+            data_frame,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/transforms/test_rechunk.py
+++ b/tests/transforms/test_rechunk.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import cast
 
 import polars as pl
 from polars.testing import assert_frame_equal
@@ -18,6 +19,26 @@ class RechunkTransform(unittest.TestCase):
                 {"a": 10, "b": 11, "c": 12},
             ],
         )
+        transformed_data = cast(
+            pl.LazyFrame, transform.transform(data_frame)
+        ).collect()
+
+        assert_frame_equal(
+            transformed_data,
+            data_frame,
+        )
+
+    def test_rechunk_lazy(self) -> None:
+        transform = Rechunk()
+
+        data_frame = pl.DataFrame(
+            [
+                {"a": 1, "b": 2, "c": 3},
+                {"a": 4, "b": 5, "c": 6},
+                {"a": 7, "b": 8, "c": 9},
+                {"a": 10, "b": 11, "c": 12},
+            ],
+        ).lazy()
         transformed_data = transform.transform(data_frame)
 
         assert_frame_equal(

--- a/tests/transforms/test_to_lazy.py
+++ b/tests/transforms/test_to_lazy.py
@@ -1,0 +1,30 @@
+import unittest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+from flowcean.transforms import ToLazy
+
+
+class ToLazyTransform(unittest.TestCase):
+    def test_to_lazy(self) -> None:
+        transform = ToLazy()
+
+        data_frame = pl.DataFrame(
+            [
+                {"a": 1, "b": 2, "c": 3},
+                {"a": 4, "b": 5, "c": 6},
+                {"a": 7, "b": 8, "c": 9},
+                {"a": 10, "b": 11, "c": 12},
+            ],
+        )
+        transformed_data = transform.transform(data_frame)
+
+        assert_frame_equal(
+            transformed_data,
+            data_frame.lazy(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR:
- Modifies existing transforms to expect lazy dataframes. This can - potentially - increase performance.
- Add a `ToLazy` and `Collect` transform which can be used to transform data from/to lazy representations.

This PR is part of greater effort to allow the usage of lazy frames within flowcean.

Waiting for #160.