### PR TITLE
Add `write_parquet` method to offline environment

### DIFF
--- a/src/flowcean/core/environment/offline.py
+++ b/src/flowcean/core/environment/offline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from pathlib import Path
 
 import polars as pl
 
@@ -33,6 +34,17 @@ class OfflineEnvironment(Environment):
             A streaming offline data.
         """
         return StreamingOfflineData(self, batch_size)
+
+    def write_parquet(self, path: Path | str) -> None:
+        """Write the environment to a parquet file at the specified path.
+
+        Write the environment to a parquet file. Use a `ParquetDataLoader` to
+        load the data back into flowcean as an environment.
+
+        Args:
+            path: Path to the parquet file where the data is written.
+        """
+        self.get_data().write_parquet(Path(path).with_suffix(".parquet"))
 
     def chain(self, other: OfflineEnvironment) -> OfflineEnvironment:
         """Combine this environment with another one vertically.


### PR DESCRIPTION
This PR:
- Adds a `write_parquet` to the offline environment. This allows the user to store data after loading / transforming it and can save time when making changes to the learners / metrics without changing the loading part. Does also support the time series representation.

This is "just" a wrapper around polars functionality - however I would argue that it's easier for a user to have a "flowcean-method" then having to dive into the polars docs. Also this makes sure the writing shows up in our documentation. If you need more options you can still use them by directly using the data frame.