### PR TITLE
Pack ALP data into single files

### DIFF
--- a/examples/automatic_lashing_platform/.gitignore
+++ b/examples/automatic_lashing_platform/.gitignore
@@ -1,3 +1,0 @@
-models/
-/data
-/real_data

--- a/examples/automatic_lashing_platform/.gitignore
+++ b/examples/automatic_lashing_platform/.gitignore
@@ -1,0 +1,2 @@
+/alp_real_data.parquet
+/alp_sim_data.parquet

--- a/examples/automatic_lashing_platform/alp_real_data.parquet.dvc
+++ b/examples/automatic_lashing_platform/alp_real_data.parquet.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: b767ae5f231c278eef96c81a90a728fa
+  size: 338519
+  hash: md5
+  path: alp_real_data.parquet

--- a/examples/automatic_lashing_platform/alp_sim_data.parquet.dvc
+++ b/examples/automatic_lashing_platform/alp_sim_data.parquet.dvc
@@ -1,0 +1,5 @@
+outs:
+- md5: 1effe0da9cbb8a0adb2028886631c152
+  size: 1146907634
+  hash: md5
+  path: alp_sim_data.parquet

--- a/examples/automatic_lashing_platform/data.dvc
+++ b/examples/automatic_lashing_platform/data.dvc
@@ -1,6 +1,0 @@
-outs:
-- md5: 570072e2b8354ab28206197333294e9a.dir
-  size: 1929251211
-  nfiles: 33476
-  hash: md5
-  path: data

--- a/examples/automatic_lashing_platform/preload_alp_data.py
+++ b/examples/automatic_lashing_platform/preload_alp_data.py
@@ -1,0 +1,38 @@
+import logging
+import time
+from pathlib import Path
+
+from tqdm import tqdm
+
+import flowcean.cli
+from flowcean.core.environment import ChainEnvironment
+from flowcean.environments.json import JsonDataLoader
+from flowcean.environments.parquet import ParquetDataLoader
+
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    flowcean.cli.initialize_logging()
+    time_start = time.time()
+    data = ChainEnvironment(
+        *[
+            ParquetDataLoader(path)
+            .load()
+            .to_time_series("t")
+            .join(JsonDataLoader(path.with_suffix(".json")).load())
+            for path in tqdm(
+                list(Path("./data").glob("*.parquet")),
+                desc="Loading environments",
+            )
+        ]
+    )
+    data.load()
+    time_end = time.time()
+    logger.info("took %.5f s to load data", time_end - time_start)
+
+    data.get_data().write_parquet(Path("./alp_sim_data.parquet"))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/automatic_lashing_platform/real_data.dvc
+++ b/examples/automatic_lashing_platform/real_data.dvc
@@ -1,6 +1,0 @@
-outs:
-- md5: a7e944094600419c050e2efbb97e4f7f.dir
-  size: 416930
-  nfiles: 46
-  hash: md5
-  path: real_data

--- a/examples/automatic_lashing_platform/run.py
+++ b/examples/automatic_lashing_platform/run.py
@@ -2,17 +2,14 @@ import logging
 import time
 from pathlib import Path
 
-from tqdm import tqdm
-
 import flowcean.cli
-from flowcean.core.environment import ChainEnvironment
-from flowcean.environments.json import JsonDataLoader
 from flowcean.environments.parquet import ParquetDataLoader
 from flowcean.environments.train_test_split import TrainTestSplit
 from flowcean.learners.regression_tree import RegressionTree
 from flowcean.metrics import MeanAbsoluteError, MeanSquaredError
 from flowcean.strategies.offline import evaluate_offline, learn_offline
 from flowcean.transforms import Flatten, Resample, Select
+from flowcean.transforms.rechunk import Rechunk
 
 logger = logging.getLogger(__name__)
 
@@ -20,18 +17,7 @@ logger = logging.getLogger(__name__)
 def main() -> None:
     flowcean.cli.initialize_logging()
     time_start = time.time()
-    data = ChainEnvironment(
-        *[
-            ParquetDataLoader(path)
-            .load()
-            .to_time_series("t")
-            .join(JsonDataLoader(path.with_suffix(".json")).load())
-            for path in tqdm(
-                list(Path("./data").glob("*.parquet")),
-                desc="Loading environments",
-            )
-        ]
-    ).with_transform(
+    data = ParquetDataLoader(Path("./alp_sim_data.parquet")).with_transform(
         Select(
             [
                 "p_accumulator",
@@ -43,7 +29,9 @@ def main() -> None:
         )
         | Resample(1.0)
         | Flatten()
+        | Rechunk()
     )
+    data.load()
     time_end = time.time()
     logger.info("took %.5f s to load data", time_end - time_start)
 


### PR DESCRIPTION
This PR:
- Repacks the ALP data into single `parquet` files and adjust the example accordingly. This makes working with the data much easier. The helper script to convert the original alp data into a single file is included as well.