### PR TITLE
Make transforms callable

### DIFF
--- a/src/flowcean/core/transform.py
+++ b/src/flowcean/core/transform.py
@@ -65,7 +65,7 @@ class Transform(ABC):
 
     @abstractmethod
     def transform(self, data: pl.DataFrame) -> pl.DataFrame:
-        """Transform the data.
+        """Transform data with this transform.
 
         Args:
             data: The data to transform.
@@ -73,6 +73,17 @@ class Transform(ABC):
         Returns:
             The transformed data.
         """
+
+    def __call__(self, data: pl.DataFrame) -> pl.DataFrame:
+        """Transform data with this transform.
+
+        Args:
+            data: The data to transform.
+
+        Returns:
+            The transformed data.
+        """
+        return self.transform(data)
 
     def __or__(self, other: Transform) -> Chain:
         """Pipe this transform into another transform.

--- a/tests/transforms/test_rechunk.py
+++ b/tests/transforms/test_rechunk.py
@@ -18,7 +18,7 @@ class RechunkTransform(unittest.TestCase):
                 {"a": 10, "b": 11, "c": 12},
             ],
         )
-        transformed_data = transform.transform(data_frame)
+        transformed_data = transform(data_frame)
 
         assert_frame_equal(
             transformed_data,


### PR DESCRIPTION
This PR:
- Make transform directly callable. This simply acts as a wrapper around the `transform` so no changes to existing transforms are required.

Closes #142.