### PR TITLE
Unpin polars and limit version to latest one with the bugfix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
 
 dependencies = [
   "numpy<2",
-  "polars==1.9",
+  "polars>=1.12",
   "ruamel.yaml",
   "typing-extensions",
   "tqdm",


### PR DESCRIPTION
This PR:
- Does what the title says. Polars since version `1.12` has the bugfix for list `evals`.