### PR TITLE
Replace www3.tuhh.de with flowcean.me domain in links

### DIFF
--- a/docs/user_guide/environment.md
+++ b/docs/user_guide/environment.md
@@ -22,7 +22,7 @@ This is often referred to as *passive online learning*.
 This is done by receiving an *Action*.
 After an action is received the environment will evolve based on the action and the previous state.
 After a set time interval or a discrete step inside a simulation, the environment can be observed again.
-Examples are a controlled simulation or a controlled live experiment. 
+Examples are a controlled simulation or a controlled live experiment.
 
 ``` mermaid
 ---
@@ -55,13 +55,11 @@ classDiagram
   }
 ```
 
-
-
-It is possible to apply [Transforms](https://www3.tuhh.de/agenc/user_guide/transforms/) to an environment.
+It is possible to apply [Transforms](https://flowcean.me/user_guide/transform/) to an environment.
 This is done by applying a transformation (e.g. resampling or normalization) to the *DataFrame* that the environment provides.
 As can be seen in the class diagram, the parent class `Environment` has a method `with_transform()` which allows to specify the transforms that are applied to an environment.
 
-Depending on the environment class, different [Learning Strategies](https://www3.tuhh.de/agenc/user_guide/learning_strategies/) can be applied.
+Depending on the environment class, different [Learning Strategies](https://flowcean.me/user_guide/learning_strategies/) can be applied.
 An active learning strategy, for example, can only be applied to an `ActiveEnvironment`.
 
-For more information on the available classes and how environments are implemented in Flowcean, check out the [API](https://www3.tuhh.de/agenc/reference/flowcean/).
+For more information on the available classes and how environments are implemented in Flowcean, check out the [API](https://flowcean.me/reference/flowcean/).

--- a/docs/user_guide/experiment.md
+++ b/docs/user_guide/experiment.md
@@ -35,13 +35,13 @@ graph LR
   Model)
 ```
 
-More information on learning strategies can be found [here](https://www3.tuhh.de/agenc/user_guide/learning_strategies/).
-How the evaluation of models is done in Flowcean, is explained [here](https://www3.tuhh.de/agenc/user_guide/evaluation/).
+More information on learning strategies can be found [here](https://flowcean.me/user_guide/learning_strategies/).
+How the evaluation of models is done in Flowcean, is explained [here](https://flowcean.me/user_guide/evaluation/).
 
 Below, is a basic code implementation of an environment definition.
-In this case, the environment is a *DataSet* which is a type of [OfflineEnvironment](https://www3.tuhh.de/agenc/reference/flowcean/core/environment/offline/).
-Its [learner](https://www3.tuhh.de/agenc/user_guide/model/) is a linear regression algorithm.
-It uses an incremental [Learning Strategy](https://www3.tuhh.de/agenc/user_guide/learning_strategies/).
+In this case, the environment is a *DataSet* which is a type of [OfflineEnvironment](https://flowcean.me/reference/flowcean/core/environment/offline/).
+Its [learner](https://flowcean.me/user_guide/model/) is a linear regression algorithm.
+It uses an incremental [Learning Strategy](https://flowcean.me/user_guide/learning_strategies/).
 In this example, no model is saved or loaded.
 The evaluation strategy is defined by the `evaluate_offline()` function.
 

--- a/docs/user_guide/learning_strategies.md
+++ b/docs/user_guide/learning_strategies.md
@@ -35,17 +35,17 @@ The three learning strategies that are already implemented are visualized and ex
 ![learning_strategies](../assets/learning_strategies.svg)
 
 In general, custom learning strategies can be constructed in a similar manner.
-All learning strategies have in common that the output is a [model](https://www3.tuhh.de/agenc/user_guide/model/).
+All learning strategies have in common that the output is a [model](https://flowcean.me/user_guide/model/).
 The model can be saved and compared to other models that might be trained in the future.
 Furthermore, the model can be used to predict states of Cyber-Physical System or detect faulty behavior.
-For more information on what can be done with a model, check out the documentation on [Tools](https://www3.tuhh.de/agenc/user_guide/tools/).
+For more information on what can be done with a model, check out the documentation on [Tools](https://flowcean.me/user_guide/tools/).
 Technically, strategies are represented as modular functions inside Flowcean.
-For more information on the implementation of the learning strategies take a look at the [API](https://www3.tuhh.de/agenc/reference/flowcean/strategies/).
+For more information on the implementation of the learning strategies take a look at the [API](https://flowcean.me/reference/flowcean/strategies/).
 
 ## Offline Learning
 
 The first step of an offline learning strategy is to get the dataset from an environment.
-This environment is typically an [OfflineEnvironment](https://www3.tuhh.de/agenc/reference/flowcean/core/environment/offline/).
+This environment is typically an [OfflineEnvironment](https://flowcean.me/reference/flowcean/core/environment/offline/).
 Along with the environment the learner requires the names of the inputs and outputs.
 Transforms can be applied to the input features of the data set and the outputs.
 The last step is to learn the model using a learning algorithm.
@@ -53,7 +53,7 @@ For this, the learning algorithm receives the entire transformed dataset at once
 
 ## Incremental Learning
 
-For the incremental learning strategy, a learner is connected to an [IncrementalEnvironment](https://www3.tuhh.de/agenc/reference/flowcean/core/environment/passive_online/).
+For the incremental learning strategy, a learner is connected to an [IncrementalEnvironment](https://flowcean.me/reference/flowcean/core/environment/incremental/).
 It iteratively receives data - either in single packets or small batches.
 Along with the environment the learner requires the names of the inputs and outputs.
 Transforms can be applied to the input features of the data set and the outputs.
@@ -63,7 +63,7 @@ The learning process stops when the environment ends, i.e. when the data stream 
 
 ## Active Learning
 
-For the active learning strategy, a learner is connected to an [ActiveEnvironment](https://www3.tuhh.de/agenc/reference/flowcean/core/environment/passive_online/).
+For the active learning strategy, a learner is connected to an [ActiveEnvironment](https://flowcean.me/reference/flowcean/core/environment/active/).
 First, the environment is observed.
 Next, the learner proposes an action which should be applied to the environment.
 This is called *acting on the environment*.

--- a/docs/user_guide/model.md
+++ b/docs/user_guide/model.md
@@ -6,10 +6,10 @@ A **learner** trains a model.
 The learner is a process that learns patterns from data.
 A learner can be based on different machine learning algorithms with various configurations.
 During the learning process the learner updates its internal parameters or structure in order to optimize its task.
-Which learners are implemented in Flowcean can be found [here](https://www3.tuhh.de/agenc/reference/flowcean/learners/).
+Which learners are implemented in Flowcean can be found [here](https://flowcean.me/reference/flowcean/learners/).
 
 Once the learner is done training, it outputs a **model**.
 The model represents the learned patterns that the learner has extracted from the data.
 The model can be used to make predictions on new, unseen data.
 Models can be saved and loaded.
-For more information take a look at the [API](https://www3.tuhh.de/agenc/reference/flowcean/core/model/).
+For more information take a look at the [API](https://flowcean.me/reference/flowcean/models/).

--- a/docs/user_guide/modules.md
+++ b/docs/user_guide/modules.md
@@ -6,7 +6,7 @@ This is achieved by organizing functionalities in modules as shown in th figure 
 ![Flowcean Modules](../assets/flowcean_modules.svg)
 
 Note, that modules described here do not coincide with Python modules on the implementation side.
-If you want to know more about a specific Python module of Flowcean please refer to the [API Reference](https://www3.tuhh.de/agenc/reference/flowcean/).
+If you want to know more about a specific Python module of Flowcean please refer to the [API Reference](https://flowcean.me/reference/flowcean/).
 In the following, the term *module* always refers to modules for the conceptual idea of Flowcean.
 Anyways, some of the Flowcean modules form Python modules as well which we discuss at the end of this page.
 
@@ -19,26 +19,25 @@ An experiment consists of
 
 An environment is a source of data.
 Thus, three major types of environments exist, namely, *Data Sets*, *Simulations*, and *Data Streams*.
-More information about the concepts and differentiation between these environments can be found in [the next section](https://www3.tuhh.de/agenc/user_guide/environment/).
+More information about the concepts and differentiation between these environments can be found in [the next section](https://flowcean.me/user_guide/environment/).
 
 Of course, a data source and, thus, an environment is as well needed for the learning phase, i.e., inside the strategy.
 In addition to that, a strategy involves a learner, representing the actual learning algorithm and, by that, the type of model learned.
-The [model section](https://www3.tuhh.de/agenc/user_guide/model/) provides more insights into the separation of learner and model modules.
+The [model section](https://flowcean.me/user_guide/model/) provides more insights into the separation of learner and model modules.
 The third element of a strategy are *Transforms*.
 Transforms are all kind of preliminary operations on data sets which might be preprocessing, abstraction, augmentation, feature engineering, etc.
 
 ## Reference to Python API
 
-On the implementation side, abstract base classes of the *Model*, *Metric*, *Learner*, and *Transform* are included in the Python module [*core*](https://www3.tuhh.de/agenc/reference/flowcean/core/).
+On the implementation side, abstract base classes of the *Model*, *Metric*, *Learner*, and *Transform* are included in the Python module [*core*](https://flowcean.me/reference/flowcean/core/).
 Furthermore, the core includes the three main environments.
 
-Concrete implementations of [models](https://www3.tuhh.de/agenc/reference/flowcean/models/), [metrics](https://www3.tuhh.de/agenc/reference/flowcean/metrics/), [learners](https://www3.tuhh.de/agenc/reference/flowcean/learners/), and [transforms](https://www3.tuhh.de/agenc/reference/flowcean/transforms/) form individual Python modules.
+Concrete implementations of [models](https://flowcean.me/reference/flowcean/models/), [metrics](https://flowcean.me/reference/flowcean/metrics/), [learners](https://flowcean.me/reference/flowcean/learners/), and [transforms](https://flowcean.me/reference/flowcean/transforms/) form individual Python modules.
 A special case is the learner module which has an additional sub-module for a gRPC-learner.
 This learner implements a universal interface to external, e.g., non-Python learners via a gRPC connection.
 Learning strategies form a further Python module.
 As strategies are Python-functions, no abstract base class exists.
-Three main strategies based on the three types of environments are explained in the section [Learning Strategies](https://www3.tuhh.de/agenc/user_guide/learning_strategies/).
+Three main strategies based on the three types of environments are explained in the section [Learning Strategies](https://flowcean.me/user_guide/learning_strategies/).
 
 The super-module *Experiment* is not a Python module, as this is the individual combination of Flowcean modules for a specific CPS application.
-Learn more about experiments in the section [Experiment](https://www3.tuhh.de/agenc/user_guide/experiment/).
-
+Learn more about experiments in the section [Experiment](https://flowcean.me/user_guide/experiment/).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://www3.tuhh.de/agenc/"
+Documentation = "https://flowcean.me/"
 Issues = "https://github.com/flowcean/flowcean/issues"
 Source = "https://github.com/flowcean/flowcean"
 


### PR DESCRIPTION
This PR:
- Replaces the old `www3.tuhh.de` domain with `flowcean.me` in documentation links.

Closes #169.