### PR TITLE
pin python version to 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "flowcean"
 dynamic = ["version"]
 description = "Automatic generation of models for cyber-physical systems."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = "==3.12.*"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: BSD License",


### PR DESCRIPTION
This should be correct if any version of 3.12 is acceptable.

Otherwise, something like that is possible: requires-python = ">=3.12.3, <3.13"