### PR TITLE
bump version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "flowcean"
-version = "0.2.0"
+version = "0.3.0"
 description = "Automatic generation of models for cyber-physical systems."
 readme = "README.md"
 requires-python = "~=3.12.7"

--- a/uv.lock
+++ b/uv.lock
@@ -686,7 +686,7 @@ wheels = [
 
 [[package]]
 name = "flowcean"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "docker" },


### PR DESCRIPTION
I created a release for `v0.2.0`, so our latest main should be `0.3.0` to avoid conflicts confusion