### PR TITLE
Add flowcean as editable dependency to scripts

### DIFF
--- a/examples/active_learning/run.py
+++ b/examples/active_learning/run.py
@@ -3,6 +3,9 @@
 # dependencies = [
 #     "flowcean",
 # ]
+#
+# [tool.uv.sources]
+# flowcean = { path = "../../", editable = true }
 # ///
 
 import logging

--- a/examples/boiler/run.py
+++ b/examples/boiler/run.py
@@ -3,6 +3,9 @@
 # dependencies = [
 #     "flowcean",
 # ]
+#
+# [tool.uv.sources]
+# flowcean = { path = "../../", editable = true }
 # ///
 
 import random

--- a/examples/coffee_machine/run.py
+++ b/examples/coffee_machine/run.py
@@ -3,6 +3,9 @@
 # dependencies = [
 #     "flowcean",
 # ]
+#
+# [tool.uv.sources]
+# flowcean = { path = "../../", editable = true }
 # ///
 
 import flowcean.cli

--- a/examples/failure_time_prediction/run.py
+++ b/examples/failure_time_prediction/run.py
@@ -3,6 +3,9 @@
 # dependencies = [
 #     "flowcean",
 # ]
+#
+# [tool.uv.sources]
+# flowcean = { path = "../../", editable = true }
 # ///
 
 import logging

--- a/examples/linear_data/run.py
+++ b/examples/linear_data/run.py
@@ -3,6 +3,9 @@
 # dependencies = [
 #     "flowcean",
 # ]
+#
+# [tool.uv.sources]
+# flowcean = { path = "../../", editable = true }
 # ///
 
 import logging

--- a/examples/one_tank/run.py
+++ b/examples/one_tank/run.py
@@ -3,6 +3,9 @@
 # dependencies = [
 #     "flowcean",
 # ]
+#
+# [tool.uv.sources]
+# flowcean = { path = "../../", editable = true }
 # ///
 
 import logging

--- a/examples/ros_offline/run.py
+++ b/examples/ros_offline/run.py
@@ -3,6 +3,9 @@
 # dependencies = [
 #     "flowcean",
 # ]
+#
+# [tool.uv.sources]
+# flowcean = { path = "../../", editable = true }
 # ///
 
 import logging

--- a/justfile
+++ b/justfile
@@ -24,28 +24,28 @@ examples: examples-alp examples-boiler examples-coffee_machine examples-failure_
 
 examples-alp:
   @echo "🚀 Running example: Automatic Lashing Platform"
-  @uv run --directory ./examples/automatic_lashing_platform/ --with-editable ../../ run.py
+  @uv run --directory ./examples/automatic_lashing_platform/ run.py
 
 examples-boiler:
   @echo "🚀 Running example: Boiler"
-  @uv run --directory ./examples/boiler/ --with-editable ../../ run.py
+  @uv run --directory ./examples/boiler/ run.py
 
 examples-coffee_machine:
   @echo "🚀 Running example: Coffee Machine"
-  @uv run --directory ./examples/coffee_machine/ --with-editable ../../ run.py
+  @uv run --directory ./examples/coffee_machine/ run.py
 
 examples-failure_time_prediction:
   @echo "🚀 Running example: Failure Time Prediction"
-  @uv run --directory ./examples/failure_time_prediction/ --with-editable ../../ run.py
+  @uv run --directory ./examples/failure_time_prediction/ run.py
 
 examples-linear_data:
   @echo "🚀 Running example: Linear Data"
-  @uv run --directory ./examples/linear_data/ --with-editable ../../ run.py
+  @uv run --directory ./examples/linear_data/ run.py
 
 examples-one_tank:
   @echo "🚀 Running example: One Tank"
-  @uv run --directory ./examples/one_tank/ --with-editable ../../ run.py
+  @uv run --directory ./examples/one_tank/ run.py
 
 examples-ros_offline:
   @echo "🚀 Running example: ROS Offline"
-  @uv run --directory ./examples/ros_offline/ --with-editable ../../ run.py
+  @uv run --directory ./examples/ros_offline/ run.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,33 +5,31 @@ description = "Automatic generation of models for cyber-physical systems."
 readme = "README.md"
 requires-python = "~=3.12.7"
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: BSD License",
-    "Operating System :: OS Independent",
-    "Topic :: Software Development :: Libraries :: Python Modules",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "License :: OSI Approved :: BSD License",
+  "Operating System :: OS Independent",
+  "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 keywords = []
-authors = [
-    { name = "The AGenC Team", email = "agenc.team@tuhh.de" }
-]
+authors = [{ name = "The AGenC Team", email = "agenc.team@tuhh.de" }]
 
 dependencies = [
-    "docker>=7.1.0",
-    "grpcio>=1.67.0",
-    "joblib>=1.4.2",
-    "lightning>=2.4.0",
-    "numpy>=1.26.4",
-    "polars>=1.9.0",
-    "protobuf>=5.28.2",
-    "rosbags-dataframe>=0.10.0",
-    "rosbags>=0.10.4",
-    "ruamel-yaml>=0.18.6",
-    "scikit-learn>=1.5.2",
-    "scipy>=1.14.1",
-    "sympy>=1.13.1",
-    "torch>=2.5.0",
-    "tqdm>=4.66.5",
+  "docker>=7.1.0",
+  "grpcio>=1.67.0",
+  "joblib>=1.4.2",
+  "lightning>=2.4.0",
+  "numpy>=1.26.4",
+  "polars>=1.9.0",
+  "protobuf>=5.28.2",
+  "rosbags-dataframe>=0.10.0",
+  "rosbags>=0.10.4",
+  "ruamel-yaml>=0.18.6",
+  "scikit-learn>=1.5.2",
+  "scipy>=1.14.1",
+  "sympy>=1.13.1",
+  "torch>=2.5.0",
+  "tqdm>=4.66.5",
 ]
 
 [project.urls]
@@ -41,30 +39,30 @@ Source = "https://github.com/flowcean/flowcean"
 
 [tool.uv]
 dev-dependencies = [
-    "deptry>=0.20.0",
-    "dvc-ssh>=4.1.1",
-    "dvc-webdav>=3.0.0",
-    "dvc>=3.55.2",
-    "mkdocs-gen-files>=0.5.0",
-    "mkdocs-literate-nav>=0.6.1",
-    "mkdocs-material>=9.5.41",
-    "mkdocs-section-index>=0.3.9",
-    "mkdocs>=1.6.1",
-    "mkdocstrings[python]>=0.26.2",
-    "pre-commit>=4.0.1",
-    "pyright>=1.1.385",
-    "pytest-cov>=5.0.0",
-    "pytest>=8.3.3",
-    "ruff>=0.7.0",
+  "deptry>=0.20.0",
+  "dvc-ssh>=4.1.1",
+  "dvc-webdav>=3.0.0",
+  "dvc>=3.55.2",
+  "mkdocs-gen-files>=0.5.0",
+  "mkdocs-literate-nav>=0.6.1",
+  "mkdocs-material>=9.5.41",
+  "mkdocs-section-index>=0.3.9",
+  "mkdocs>=1.6.1",
+  "mkdocstrings[python]>=0.26.2",
+  "pre-commit>=4.0.1",
+  "pyright>=1.1.385",
+  "pytest-cov>=5.0.0",
+  "pytest>=8.3.3",
+  "ruff>=0.7.0",
 ]
 
 [tool.uv.workspace]
 members = [
-    "flowcean-sklearn",
-    "flowcean-pytorch",
-    "flowcean-ros",
-    "flowcean-ode",
-    "flowcean-grpc"
+  "flowcean-sklearn",
+  "flowcean-pytorch",
+  "flowcean-ros",
+  "flowcean-ode",
+  "flowcean-grpc",
 ]
 
 [build-system]
@@ -75,35 +73,27 @@ build-backend = "hatchling.build"
 packages = ["src/flowcean"]
 
 [tool.hatch.build.targets.sdist]
-include = [
-  "*.py",
-]
+include = ["*.py"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
 [tool.pyright]
-ignore = [
-    "src/flowcean/learners/grpc/_generated/*",
-]
+ignore = ["src/flowcean/learners/grpc/_generated/*"]
 pythonVersion = "3.12"
-strict = [
-  "src/flowcean/core",
-]
+strict = ["src/flowcean/core"]
 
 [tool.coverage.run]
 source_pkgs = ["flowcean"]
-omit = [
-    "src/flowcean/learners/grpc/_generated/*",
-]
+omit = ["src/flowcean/learners/grpc/_generated/*"]
 branch = true
 parallel = true
 
 [tool.coverage.report]
 skip_empty = true
 exclude_also = [
-    "pass",
-    "raise NotImplementedError",
-    "if __name__ == .__main__.:",
-    "if TYPE_CHECKING:",
+  "pass",
+  "raise NotImplementedError",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ name = "click"
 version = "8.1.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
 wheels = [
@@ -346,6 +346,9 @@ name = "configobj"
 version = "5.0.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f5/c4/c7f9e41bc2e5f8eeae4a08a01c91b2aea3dfab40a3e14b25e87e7db8d501/configobj-5.0.9.tar.gz", hash = "sha256:03c881bbf23aa07bccf1b837005975993c4ab4427ba57f959afdd9d1a2386848", size = 101518 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/c4/0679472c60052c27efa612b4cd3ddd2a23e885dcdc73461781d2c802d39e/configobj-5.0.9-py2.py3-none-any.whl", hash = "sha256:1ba10c5b6ee16229c79a05047aeda2b55eb4e80d7c7d8ecf17ec1ca600c79882", size = 35615 },
+]
 
 [[package]]
 name = "coverage"
@@ -1164,7 +1167,7 @@ version = "1.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "ghp-import" },
     { name = "jinja2" },
     { name = "markdown" },
@@ -2069,6 +2072,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/a9/d39f3c5ada0a3bb2870d7db41901125dbe2434fa4f12ca8c5b83a42d7c53/ruamel.yaml.clib-0.2.12-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:749c16fcc4a2b09f28843cda5a193e0283e47454b63ec4b81eaa2242f50e4ccd", size = 706497 },
     { url = "https://files.pythonhosted.org/packages/b0/fa/097e38135dadd9ac25aecf2a54be17ddf6e4c23e43d538492a90ab3d71c6/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bf165fef1f223beae7333275156ab2022cffe255dcc51c27f066b4370da81e31", size = 698042 },
     { url = "https://files.pythonhosted.org/packages/ec/d5/a659ca6f503b9379b930f13bc6b130c9f176469b73b9834296822a83a132/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:32621c177bbf782ca5a18ba4d7af0f1082a3f6e517ac2a18b3974d4edf349680", size = 745831 },
+    { url = "https://files.pythonhosted.org/packages/db/5d/36619b61ffa2429eeaefaab4f3374666adf36ad8ac6330d855848d7d36fd/ruamel.yaml.clib-0.2.12-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b82a7c94a498853aa0b272fd5bc67f29008da798d4f93a2f9f289feb8426a58d", size = 715692 },
     { url = "https://files.pythonhosted.org/packages/b1/82/85cb92f15a4231c89b95dfe08b09eb6adca929ef7df7e17ab59902b6f589/ruamel.yaml.clib-0.2.12-cp312-cp312-win32.whl", hash = "sha256:e8c4ebfcfd57177b572e2040777b8abc537cdef58a2120e830124946aa9b42c5", size = 98777 },
     { url = "https://files.pythonhosted.org/packages/d7/8f/c3654f6f1ddb75daf3922c3d8fc6005b1ab56671ad56ffb874d908bfa668/ruamel.yaml.clib-0.2.12-cp312-cp312-win_amd64.whl", hash = "sha256:0467c5965282c62203273b838ae77c0d29d7638c8a4e3a1c8bdd3602c10904e4", size = 115523 },
 ]
@@ -2309,21 +2313,21 @@ dependencies = [
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and platform_system == 'Linux'" },
+    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
@@ -2353,7 +2357,7 @@ name = "tqdm"
 version = "4.67.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e8/4f/0153c21dc5779a49a0598c445b1978126b1344bab9ee71e53e44877e14e0/tqdm-4.67.0.tar.gz", hash = "sha256:fe5a6f95e6fe0b9755e9469b77b9c3cf850048224ecaa8293d7d2d31f97d869a", size = 169739 }
 wheels = [


### PR DESCRIPTION
Currently, flowcean is installed from official released sources (pypi) when scripts are run with `uv`.
This PR adds a section telling `uv` to use flowcean from the local path instead.
