### PR TITLE
Add Model saving and loading

### DIFF
--- a/examples/active_learning/run.py
+++ b/examples/active_learning/run.py
@@ -14,7 +14,7 @@ import logging
 import random
 from math import nan
 from pathlib import Path
-from typing import BinaryIO
+from typing import Any, BinaryIO
 
 import polars as pl
 from typing_extensions import override
@@ -89,14 +89,13 @@ class MyModel(Model):
         ).lazy()
 
     @override
-    def save(self, file: BinaryIO) -> None:
-        _ = file
+    def save_state(self) -> dict[str, Any]:
         raise NotImplementedError
 
     @override
     @classmethod
-    def load(cls, file: BinaryIO) -> MyModel:
-        _ = file
+    def load_from_state(cls, state: dict[str, Any]) -> MyModel:
+        _ = state
         raise NotImplementedError
 
 

--- a/examples/active_learning/run.py
+++ b/examples/active_learning/run.py
@@ -8,10 +8,13 @@
 # flowcean = { path = "../../", editable = true }
 # ///
 
+from __future__ import annotations
+
 import logging
 import random
 from math import nan
 from pathlib import Path
+from typing import BinaryIO
 
 import polars as pl
 from typing_extensions import override
@@ -86,13 +89,14 @@ class MyModel(Model):
         ).lazy()
 
     @override
-    def save(self, path: Path) -> None:
-        _ = path
+    def save(self, file: BinaryIO) -> None:
+        _ = file
         raise NotImplementedError
 
     @override
-    def load(self, path: Path) -> None:
-        _ = path
+    @classmethod
+    def load(cls, file: BinaryIO) -> MyModel:
+        _ = file
         raise NotImplementedError
 
 

--- a/examples/active_learning/run.py
+++ b/examples/active_learning/run.py
@@ -13,8 +13,7 @@ from __future__ import annotations
 import logging
 import random
 from math import nan
-from pathlib import Path
-from typing import Any, BinaryIO
+from typing import Any
 
 import polars as pl
 from typing_extensions import override

--- a/src/flowcean/core/model.py
+++ b/src/flowcean/core/model.py
@@ -10,11 +10,10 @@ from typing import TYPE_CHECKING, Any, BinaryIO, cast, final
 
 from typing_extensions import override
 
-from flowcean.core.data import Data
-from flowcean.core.transform import Transform
-
 if TYPE_CHECKING:
-    import polars as pl
+    from flowcean.core.data import Data
+    from flowcean.core.transform import Transform
+
 
 class Model(ABC):
     """Base class for models.

--- a/src/flowcean/core/model.py
+++ b/src/flowcean/core/model.py
@@ -36,6 +36,17 @@ class Model(ABC):
     def save(self, file: Path | BinaryIO) -> None:
         """Save the model to the file.
 
+        This method can be used to save a flowcean model to a file or a
+        file-like object. To save a model to a file use
+
+        ```python
+        with open("model.fml", "wb") as f:
+            model.save(f)
+        ```
+
+        The resulting file will contain the model any any attached transforms.
+        It can be loaded again using the `load` method from the `Model` class.
+
         Args:
             file: The file like object to save the model to.
         """

--- a/src/flowcean/core/model.py
+++ b/src/flowcean/core/model.py
@@ -55,15 +55,16 @@ class ModelWithTransform(Model):
     """
 
     model: Model
-    transform: Transform
+    input_transform: Transform
+    output_transform: Transform
 
     @override
     def predict(
         self,
         input_features: pl.LazyFrame,
     ) -> pl.LazyFrame:
-        transformed = self.transform.apply(input_features)
-        return self.model.predict(transformed)
+        transformed = self.input_transform.apply(input_features)
+        return self.output_transform.apply(self.model.predict(transformed))
 
     @override
     def save(self, path: Path) -> None:

--- a/src/flowcean/core/model.py
+++ b/src/flowcean/core/model.py
@@ -5,7 +5,7 @@ import pickle
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Any, BinaryIO, cast
+from typing import Any, BinaryIO, cast, final
 
 import polars as pl
 from typing_extensions import override
@@ -33,21 +33,63 @@ class Model(ABC):
             The predicted outputs.
         """
 
-    @abstractmethod
+    @final
     def save(self, file: BinaryIO) -> None:
         """Save the model to the file.
 
         Args:
             file: The file like object to save the model to.
         """
+        data = {
+            "model": self.save_state(),
+            "model_type": fullname(self),
+        }
+        pickle.dump(data, file)
 
-    @classmethod
-    @abstractmethod
-    def load(cls, file: BinaryIO) -> Model:
+    @staticmethod
+    def load(file: BinaryIO) -> Model:
         """Load the model from file.
 
         Args:
             file: The file like object to load the model from.
+        """
+        # Read the general model from the file
+        data = pickle.load(file)  # noqa: S301
+        if not isinstance(data, dict):
+            msg = "Invalid model file"
+            raise ValueError(msg)  # noqa: TRY004, it's really a value error and not a type error
+        data = cast(dict[str, Any], data)
+
+        # Create a model based on the type
+        model_type = data["model_type"]
+        module_name, class_name = model_type.rsplit(".", 1)
+        module = importlib.import_module(module_name)
+        model_class = getattr(module, class_name)
+
+        return model_class.load_from_state(data["model"])
+
+    @abstractmethod
+    def save_state(self) -> dict[str, Any]:
+        """Save the model state to a dictionary.
+
+        To save the model to a file, use the `save` method.
+        To create a model from a state dictionary, use the `load_from_state`
+        method.
+
+        Returns:
+            A dictionary containing the model state.
+        """
+
+    @classmethod
+    @abstractmethod
+    def load_from_state(cls, state: dict[str, Any]) -> Model:
+        """Load the model from a state dictionary.
+
+        To load a model from a file use the `load` method.
+        To save the model state to a dictionary, use the `save_state` method.
+
+        Args:
+            state: A dictionary containing the model state.
         """
 
 
@@ -73,7 +115,7 @@ class ModelWithTransform(Model):
         return self.output_transform.apply(self.model.predict(transformed))
 
     @override
-    def save(self, file: BinaryIO) -> None:
+    def save_state(self) -> dict[str, Any]:
         model_bytes = BytesIO()
         self.model.save(model_bytes)
         model_bytes.seek(0)
@@ -86,31 +128,18 @@ class ModelWithTransform(Model):
         pickle.dump(self.output_transform, output_bytes)
         output_bytes.seek(0)
 
-        data = {
+        return {
             "model": model_bytes.read(),
-            "model_type": fullname(self.model),
             "input_transform": input_bytes.read(),
             "output_transform": output_bytes.read(),
         }
-        pickle.dump(
-            data,
-            file,
-        )
 
     @override
     @classmethod
-    def load(cls, file: BinaryIO) -> ModelWithTransform:
-        data = pickle.load(file)  # noqa: S301
-
-        # Create a model based on the type
-        model_type = data["model_type"]
-        module_name, class_name = model_type.rsplit(".", 1)
-        module = importlib.import_module(module_name)
-        model_class = getattr(module, class_name)
-
-        model = cast(Model, model_class.load(BytesIO(data["model"])))
-        input_transform = pickle.load(BytesIO(data["input_transform"]))  # noqa: S301
-        output_transform = pickle.load(BytesIO(data["output_transform"]))  # noqa: S301
+    def load_from_state(cls, state: dict[str, Any]) -> ModelWithTransform:
+        model = Model.load(BytesIO(state["model"]))
+        input_transform = pickle.load(BytesIO(state["input_transform"]))  # noqa: S301
+        output_transform = pickle.load(BytesIO(state["output_transform"]))  # noqa: S301
 
         return cls(model, input_transform, output_transform)
 

--- a/src/flowcean/core/model.py
+++ b/src/flowcean/core/model.py
@@ -51,7 +51,24 @@ class Model(ABC):
 
     @staticmethod
     def load(file: Path | BinaryIO) -> Model:
-        """Load the model from file.
+        """Load a model from file.
+
+        This method can be used to load a previously saved flowcean model from
+        a file or a file-like object.
+        To load a model from a file use
+
+        ```python
+        with open("model.fml", "rb") as f:
+            model = Model.load(f)
+        ```
+
+        The `load` method will automatically determine the model type and and
+        any attached transforms and will load them into the correct model
+        class.
+
+        As this method uses the `pickle` module to load the model, it is not
+        safe to load models from untrusted sources as this could lead to
+        arbitrary code execution!
 
         Args:
             file: The file like object to load the model from.

--- a/src/flowcean/learners/dummy_learner.py
+++ b/src/flowcean/learners/dummy_learner.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from pathlib import Path
+from typing import BinaryIO
 
 import polars as pl
 from typing_extensions import override
@@ -31,12 +34,13 @@ class DummyModel(Model):
         ).lazy()
 
     @override
-    def save(self, path: Path) -> None:
+    def save(self, file: BinaryIO) -> None:
         pass
 
     @override
-    def load(self, path: Path) -> None:
-        pass
+    @classmethod
+    def load(cls, file: BinaryIO) -> DummyModel:
+        return cls([])
 
 
 class DummyLearner(SupervisedLearner):

--- a/src/flowcean/learners/dummy_learner.py
+++ b/src/flowcean/learners/dummy_learner.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import BinaryIO
+from typing import Any, BinaryIO
 
 import polars as pl
 from typing_extensions import override
@@ -34,13 +34,13 @@ class DummyModel(Model):
         ).lazy()
 
     @override
-    def save(self, file: BinaryIO) -> None:
-        pass
+    def save_state(self) -> dict[str, Any]:
+        return {"output_names": self.output_names}
 
     @override
     @classmethod
-    def load(cls, file: BinaryIO) -> DummyModel:
-        return cls([])
+    def load_from_state(cls, state: dict[str, Any]) -> DummyModel:
+        return cls(state["output_names"])
 
 
 class DummyLearner(SupervisedLearner):

--- a/src/flowcean/learners/dummy_learner.py
+++ b/src/flowcean/learners/dummy_learner.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any, BinaryIO
+from typing import Any
 
 import polars as pl
 from typing_extensions import override

--- a/src/flowcean/learners/grpc/learner.py
+++ b/src/flowcean/learners/grpc/learner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, BinaryIO
+from typing import TYPE_CHECKING, Any
 
 import docker
 import grpc
@@ -210,14 +210,13 @@ class GrpcLearner(SupervisedLearner, Model):
         self.channel.close()
 
     @override
-    def save(self, file: BinaryIO) -> None:
-        _ = file
+    def save_state(self) -> dict[str, Any]:
         raise NotImplementedError
 
     @override
     @classmethod
-    def load(cls, file: BinaryIO) -> GrpcLearner:
-        _ = file
+    def load_from_state(cls, state: dict[str, Any]) -> GrpcLearner:
+        _ = state
         raise NotImplementedError
 
 

--- a/src/flowcean/learners/grpc/learner.py
+++ b/src/flowcean/learners/grpc/learner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, BinaryIO
 
 import docker
 import grpc
@@ -27,7 +27,6 @@ from ._generated.learner_pb2_grpc import LearnerStub
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from pathlib import Path
 
 MAX_MESSAGE_LENGTH = 1024 * 1024 * 1024
 
@@ -211,13 +210,14 @@ class GrpcLearner(SupervisedLearner, Model):
         self.channel.close()
 
     @override
-    def save(self, path: Path) -> None:
-        _ = path
+    def save(self, file: BinaryIO) -> None:
+        _ = file
         raise NotImplementedError
 
     @override
-    def load(self, path: Path) -> None:
-        _ = path
+    @classmethod
+    def load(cls, file: BinaryIO) -> GrpcLearner:
+        _ = file
         raise NotImplementedError
 
 

--- a/src/flowcean/models/pytorch.py
+++ b/src/flowcean/models/pytorch.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
 from io import BytesIO
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import polars as pl
 import torch
-from torch.nn import Module
 from torch.utils.data import DataLoader
 from typing_extensions import override
 
 from flowcean.core.model import Model
 from flowcean.environments.pytorch import TorchDataset
+
+if TYPE_CHECKING:
+    from torch.nn import Module
 
 
 class PyTorchModel(Model):

--- a/src/flowcean/models/sklearn.py
+++ b/src/flowcean/models/sklearn.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import pickle
 from io import BytesIO
-from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
 
 import joblib
 import polars as pl
@@ -38,17 +37,15 @@ class SciKitModel(Model):
         return pl.DataFrame({self.output_name: outputs}).lazy()
 
     @override
-    def save(self, path: Path) -> None:
+    def save(self, file: BinaryIO) -> None:
         model_bytes = BytesIO()
         joblib.dump(self.model, model_bytes)
         model_bytes.seek(0)
         data = {"data": model_bytes.read(), "output_name": self.output_name}
-        with path.open("wb") as file:
-            pickle.dump(data, file)
+        pickle.dump(data, file)
 
     @override
     @classmethod
-    def load(cls, path: Path) -> SciKitModel:
-        with path.open("rb") as file:
-            data = pickle.load(file)  # noqa: S301
+    def load(cls, file: BinaryIO) -> SciKitModel:
+        data = pickle.load(file)  # noqa: S301
         return cls(joblib.load(BytesIO(data["data"])), data["output_name"])

--- a/src/flowcean/strategies/incremental.py
+++ b/src/flowcean/strategies/incremental.py
@@ -1,7 +1,7 @@
 from flowcean.core.environment.incremental import IncrementalEnvironment
 from flowcean.core.learner import SupervisedIncrementalLearner
 from flowcean.core.model import Model, ModelWithTransform
-from flowcean.core.transform import FitIncremetally, Identity, Transform
+from flowcean.core.transform import FitIncremetally, Transform
 
 
 def learn_incremental(

--- a/src/flowcean/strategies/incremental.py
+++ b/src/flowcean/strategies/incremental.py
@@ -1,7 +1,7 @@
 from flowcean.core.environment.incremental import IncrementalEnvironment
 from flowcean.core.learner import SupervisedIncrementalLearner
 from flowcean.core.model import Model, ModelWithTransform
-from flowcean.core.transform import FitIncremetally, Transform
+from flowcean.core.transform import FitIncremetally, Identity, Transform
 
 
 def learn_incremental(
@@ -43,5 +43,9 @@ def learn_incremental(
         message = "No data found in environment."
         raise ValueError(message)
     if input_transform is not None:
-        return ModelWithTransform(model=model, transform=input_transform)
+        return ModelWithTransform(
+            model=model,
+            input_transform=input_transform,
+            output_transform=Identity(),
+        )
     return model

--- a/src/flowcean/strategies/offline.py
+++ b/src/flowcean/strategies/offline.py
@@ -4,7 +4,12 @@ from typing import cast
 from flowcean.core.learner import SupervisedLearner
 from flowcean.core.metric import OfflineMetric
 from flowcean.core.model import Model, ModelWithTransform
-from flowcean.core.transform import FitIncremetally, FitOnce, Transform
+from flowcean.core.transform import (
+    FitIncremetally,
+    FitOnce,
+    Identity,
+    Transform,
+)
 from flowcean.environments.dataset import OfflineEnvironment
 from flowcean.metrics.report import Report
 
@@ -53,8 +58,9 @@ def learn_offline(
     if input_transform is None:
         return model
     return ModelWithTransform(
-        model,
-        input_transform,
+        model=model,
+        input_transform=input_transform,
+        output_transform=Identity(),
     )
 
 

--- a/src/flowcean/strategies/offline.py
+++ b/src/flowcean/strategies/offline.py
@@ -6,7 +6,6 @@ from flowcean.core.model import Model, ModelWithTransform
 from flowcean.core.transform import (
     FitIncremetally,
     FitOnce,
-    Identity,
     Transform,
 )
 from flowcean.environments.dataset import OfflineEnvironment

--- a/tests/models/save_load.py
+++ b/tests/models/save_load.py
@@ -51,10 +51,10 @@ class TestSaveLoad(unittest.TestCase):
         # Test a random prediction
         test_frame = pl.DataFrame(
             {"x": [0.5]},
-        )
+        ).lazy()
         assert_frame_equal(
-            model.predict(test_frame),
-            loaded_model.predict(test_frame),
+            model.predict(test_frame).collect(),
+            loaded_model.predict(test_frame).collect(),
         )
 
     def test_save_load_pytorch(self) -> None:
@@ -95,10 +95,10 @@ class TestSaveLoad(unittest.TestCase):
         # Test a random prediction
         test_frame = pl.DataFrame(
             {"x": [0.5]},
-        )
+        ).lazy()
         assert_frame_equal(
-            model.predict(test_frame),
-            loaded_model.predict(test_frame),
+            model.predict(test_frame).collect(),
+            loaded_model.predict(test_frame).collect(),
         )
 
     def test_save_load_model_with_transforms(self) -> None:
@@ -136,10 +136,10 @@ class TestSaveLoad(unittest.TestCase):
         # Test a random prediction
         test_frame = pl.DataFrame(
             {"x": [0.5]},
-        )
+        ).lazy()
         assert_frame_equal(
-            model.predict(test_frame),
-            loaded_model.predict(test_frame),
+            model.predict(test_frame).collect(),
+            loaded_model.predict(test_frame).collect(),
         )
 
 

--- a/tests/models/save_load.py
+++ b/tests/models/save_load.py
@@ -1,0 +1,147 @@
+import unittest
+from io import BytesIO
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+from flowcean.core.model import Model, ModelWithTransform
+from flowcean.environments.dataset import Dataset
+from flowcean.environments.train_test_split import TrainTestSplit
+from flowcean.learners.linear_regression import LinearRegression
+from flowcean.learners.regression_tree import RegressionTree
+from flowcean.models.pytorch import PyTorchModel
+from flowcean.models.sklearn import SciKitModel
+from flowcean.strategies.incremental import learn_incremental
+from flowcean.strategies.offline import learn_offline
+from flowcean.transforms import Select
+
+
+class TestSaveLoad(unittest.TestCase):
+    def test_save_load_sklearn(self) -> None:
+        n = 100
+        data = Dataset(
+            pl.DataFrame(
+                {
+                    "x": pl.arange(0, n, eager=True).cast(pl.Float32) / n,
+                    "y": pl.arange(n, 0, -1, eager=True).cast(pl.Float32) / n,
+                },
+            ),
+        )
+
+        train_env, test_env = TrainTestSplit(ratio=0.8, shuffle=False).split(
+            data,
+        )
+
+        learner = RegressionTree()
+        model = learn_offline(
+            train_env,
+            learner,
+            ["x"],
+            ["y"],
+        )
+
+        assert isinstance(model, SciKitModel)
+        model_bytes = BytesIO()
+        model.save(model_bytes)
+        model_bytes.seek(0)
+
+        loaded_model = Model.load(model_bytes)
+        assert isinstance(loaded_model, SciKitModel)
+
+        # Test a random prediction
+        test_frame = pl.DataFrame(
+            {"x": [0.5]},
+        )
+        assert_frame_equal(
+            model.predict(test_frame),
+            loaded_model.predict(test_frame),
+        )
+
+    def test_save_load_pytorch(self) -> None:
+        n = 100
+        data = Dataset(
+            pl.DataFrame(
+                {
+                    "x": pl.arange(0, n, eager=True).cast(pl.Float32) / n,
+                    "y": pl.arange(n, 0, -1, eager=True).cast(pl.Float32) / n,
+                },
+            ),
+        )
+
+        train_env, test_env = TrainTestSplit(ratio=0.8, shuffle=False).split(
+            data,
+        )
+
+        learner = LinearRegression(
+            input_size=1,
+            output_size=1,
+            learning_rate=0.01,
+        )
+        model = learn_incremental(
+            train_env.as_stream(batch_size=1),
+            learner,
+            ["x"],
+            ["y"],
+        )
+
+        assert isinstance(model, PyTorchModel)
+        model_bytes = BytesIO()
+        model.save(model_bytes)
+        model_bytes.seek(0)
+
+        loaded_model = Model.load(model_bytes)
+        assert isinstance(loaded_model, PyTorchModel)
+
+        # Test a random prediction
+        test_frame = pl.DataFrame(
+            {"x": [0.5]},
+        )
+        assert_frame_equal(
+            model.predict(test_frame),
+            loaded_model.predict(test_frame),
+        )
+
+    def test_save_load_model_with_transforms(self) -> None:
+        n = 100
+        data = Dataset(
+            pl.DataFrame(
+                {
+                    "x": pl.arange(0, n, eager=True).cast(pl.Float32) / n,
+                    "y": pl.arange(n, 0, -1, eager=True).cast(pl.Float32) / n,
+                },
+            ),
+        )
+
+        train_env, test_env = TrainTestSplit(ratio=0.8, shuffle=False).split(
+            data,
+        )
+
+        learner = RegressionTree()
+        model = learn_offline(
+            train_env,
+            learner,
+            ["x"],
+            ["y"],
+            input_transform=Select(pl.col("x") * 2),
+        )
+
+        assert isinstance(model, ModelWithTransform)
+        model_bytes = BytesIO()
+        model.save(model_bytes)
+        model_bytes.seek(0)
+
+        loaded_model = Model.load(model_bytes)
+        assert isinstance(loaded_model, ModelWithTransform)
+
+        # Test a random prediction
+        test_frame = pl.DataFrame(
+            {"x": [0.5]},
+        )
+        assert_frame_equal(
+            model.predict(test_frame),
+            loaded_model.predict(test_frame),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR:
- Adds code to load and save all existing models
- Adds code to load and save models with transforms, rapping arbitrary model types

ToDos:
- [x] Check if scikits regression trees can be saved and loaded
- [x] Check if pytorch neural networks can be saved and loaded
- [x] Check (most) transforms
- [x] Add tests to ensure loading and saving works as intended

This PR relies heavily on `pickle` and untyped dict access. It's not nice, but it works for now!
The only downside is: We cannot save `Lambda` transforms with this approach, because lambda functions aren't supported by `pickle` alone. However we could use `dill` a `pickle` extension which supports nearly everything python has to offer. Any feelings about this?