### PR TITLE
Add Prediction Environment

### DIFF
--- a/src/flowcean/environments/datasetprediction.py
+++ b/src/flowcean/environments/datasetprediction.py
@@ -1,0 +1,60 @@
+from typing import override
+
+import polars as pl
+
+from flowcean.core.environment.active import ActiveEnvironment
+from flowcean.core.environment.stepable import Finished
+from flowcean.environments.dataset import Dataset
+
+
+class DatasetPredictionEnvironment(ActiveEnvironment):
+    """Dataset prediction environment."""
+
+    environment: Dataset
+    batch_size: int
+    data: pl.LazyFrame | None = None
+    slice: pl.LazyFrame | None = None
+    i: int = 0
+
+    def __init__(
+        self,
+        environment: Dataset,
+        batch_size: int,
+    ) -> None:
+        """Initialize the dataset prediction environment.
+
+        Args:
+            environment: The dataset to use for prediction.
+            batch_size: The batch size of the prediction.
+        """
+        super().__init__()
+        self.environment = environment
+        self.batch_size = batch_size
+
+    @override
+    def _observe(self) -> pl.LazyFrame:
+        if self.data is None:
+            self.data = self.environment.observe()
+        if self.slice is None:
+            self.slice = self.data.slice(self.i, self.batch_size)
+        print("Provided input for prediction is: ", self.slice)
+        return self.slice.lazy()
+
+    @override
+    def step(self) -> None:
+        if self.data is None:
+            self.data = self.environment.observe()
+        self.i += self.batch_size
+        self.slice = self.data.slice(self.i, self.batch_size)
+        if (
+            self.slice.slice(0, 1)
+            .collect(streaming=False)
+            .select(pl.len())
+            .item(0, 0)
+            == 0
+        ):
+            raise Finished
+
+    @override
+    def act(self, action: pl.DataFrame) -> None:
+        print("The predicted output is: ", action)


### PR DESCRIPTION
Resolves #191 

The PR implements a mock environment for prediction. The environment is mainly a wrapper for the `Dataset` environment which prints the prediction result to the console.

Open Questions for Review:
- The environment's ´observe` and `step` functions are nearly equivalent to the `Streaming`-environment. Should we derive the `DatasetPredictionEnvironment` from the ´Streaming`-environment (and `Actable`environment) instead to avoid duplicated code? In this case, the environment doesn't wrap a `Dataset`environment, but a general `OfflineEnvironment`.
- There are no tests for this environment. I am not sure whether there exist useful test cases.
