### PR TITLE
Adapt pre-release check according to PEP440

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,9 @@ jobs:
         id: version
         run: |
           VERSION=${GITHUB_REF#refs/*/v}
-          if [[ "$VERSION" == *"-"* ]]; then
+          # Check if the version has a pre-release segment (a, b, or rc followed by digits)
+          # or a developmental release segment (".dev" followed by digits).
+          if [[ "$VERSION" =~ ((a|b|rc)[0-9]+)|(\.dev[0-9]+) ]]; then
             IS_PRERELEASE=true
           else
             IS_PRERELEASE=false


### PR DESCRIPTION
Adapt pre-release check according to https://peps.python.org/pep-0440/
Treating pre-releases and development releases as pre-releases on github
