### PR TITLE
Replace flag for Median transform

### DIFF
--- a/src/flowcean/polars/transforms/median.py
+++ b/src/flowcean/polars/transforms/median.py
@@ -12,23 +12,34 @@ logger = logging.getLogger(__name__)
 class Median(Transform):
     """Replaces time-series features with their median value."""
 
-    def __init__(self, features: str | Iterable[str]) -> None:
+    def __init__(
+        self,
+        features: str | Iterable[str],
+        *,
+        replace: bool = False,
+    ) -> None:
         """Initializes the Median transform.
 
         Args:
             features: The feature or features the median should be calculated
                 for.
+            replace: Whether to replace the original features with the
+                transformed ones. If set to False, the default, the value will
+                be added as a new feature named `{feature}_median`.
         """
         self.features = [features] if isinstance(features, str) else features
+        self.replace = replace
 
     @override
     def apply(self, data: pl.LazyFrame) -> pl.LazyFrame:
         for feature in self.features:
-            data = data.with_columns(
+            expr = (
                 pl.col(feature)
                 .list.eval(pl.element().struct.field("value"))
                 .list.median()
-                .alias(f"{feature}_median"),
+            )
+            data = data.with_columns(
+                expr if self.replace else expr.alias(f"{feature}_median"),
             )
 
         return data

--- a/tests/polars/transforms/test_median.py
+++ b/tests/polars/transforms/test_median.py
@@ -3,50 +3,75 @@ import unittest
 import polars as pl
 from polars.testing import assert_frame_equal
 
-from flowcean.polars.transforms import Median, ToTimeSeries
+from flowcean.polars.transforms import Median
 
 
 class MedianTransform(unittest.TestCase):
     def test_single_feature(self) -> None:
         transform = Median("a")
 
-        data_frame_a = pl.DataFrame(
-            [
-                {"t": 0, "a": 0},
-                {"t": 1, "a": 5},
-                {"t": 2, "a": 10},
-            ],
-        ).lazy()
-
-        data_frame_b = pl.DataFrame(
-            [
-                {"t": 0, "a": -100},
-                {"t": 1, "a": 50},
-                {"t": 2, "a": 50},
-            ],
-        ).lazy()
-
-        time_series_transform = ToTimeSeries(time_feature="t")
-        time_series_data_frame_a = time_series_transform(data_frame_a)
-        time_series_data_frame_b = time_series_transform(data_frame_b)
-
-        transformed_data = transform(
-            pl.concat(
-                [
-                    time_series_data_frame_a,
-                    time_series_data_frame_b,
+        data_frame = pl.DataFrame(
+            {
+                "a": [
+                    [
+                        {"time": 0, "value": 0},
+                        {"time": 1, "value": 5},
+                        {"time": 2, "value": 10},
+                    ],
+                    [
+                        {"time": 0, "value": -100},
+                        {"time": 1, "value": 50},
+                        {"time": 2, "value": 50},
+                    ],
                 ],
-                how="vertical",
-            ),
-        ).collect()
+            },
+        )
+
+        transformed_data = transform(data_frame.lazy()).collect()
 
         assert_frame_equal(
-            transformed_data.select(pl.col("a_median")),
-            pl.DataFrame(
+            transformed_data,
+            pl.concat(
                 [
-                    {"a_median": 5.0},
-                    {"a_median": 50.0},
+                    data_frame,
+                    pl.DataFrame(
+                        {
+                            "a_median": [5.0, 50.0],
+                        },
+                    ),
                 ],
+                how="horizontal",
+            ),
+        )
+
+    def test_replace_single_feature(self) -> None:
+        transform = Median("a", replace=True)
+
+        data_frame = pl.DataFrame(
+            {
+                "a": [
+                    [
+                        {"time": 0, "value": 0},
+                        {"time": 1, "value": 5},
+                        {"time": 2, "value": 10},
+                    ],
+                    [
+                        {"time": 0, "value": -100},
+                        {"time": 1, "value": 50},
+                        {"time": 2, "value": 50},
+                    ],
+                ],
+            },
+        )
+
+        transformed_data = transform(data_frame.lazy()).collect()
+
+        assert_frame_equal(
+            transformed_data,
+            pl.DataFrame(
+                {
+                    "a": [5.0, 50.0],
+                },
             ),
         )
 


### PR DESCRIPTION
This PR:
- Adds a `replace` flag to the `Median` transform.
- Adjust the tests for `Median` and `Mean` transform to test for feature replacements.