### PR TITLE
Remove unused workspace members

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,9 @@ dev = [
   "ruff>=0.9.2",
 ]
 
-examples = ["matplotlib>=3.10.0", "opencv-python>=4.11.0.86",   "pillow>=11.1.0"]
+examples = ["matplotlib>=3.10.0", "opencv-python>=4.11.0.86", "pillow>=11.1.0"]
 
 [tool.uv.workspace]
-members = ["flowcean-sklearn", "flowcean-pytorch", "flowcean-ros", "flowcean-ode", "flowcean-grpc"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/flowcean"]


### PR DESCRIPTION
We currently do not use workspaces, this is a leftover from a previous attempt of using workspaces for flowcean project structure.

This PR simply removes this...
