### PR TITLE
Cast dictionary argument

### DIFF
--- a/src/flowcean/polars/transforms/cast.py
+++ b/src/flowcean/polars/transforms/cast.py
@@ -11,7 +11,35 @@ logger = logging.getLogger(__name__)
 
 
 class Cast(Transform):
-    """Cast features to a different datatype."""
+    """Cast features to a different datatype.
+
+    This transform allows to change the datatype of features in a DataFrame.
+    To cast all features to the same datatype, provide a single type as the
+    `target_type` argument e.g.
+
+    ```python
+    transform = Cast(pl.Float64)
+    ```
+
+    By specifying the `features` keyword argument, only the selected features
+    will be cast e.g.
+
+    ```python
+    transform = Cast(pl.Float64, features=["feature_a"])
+    ```
+
+    Lastly, to cast features to different datatypes, provide a dictionary with
+    feature names as keys and target types as values e.g.
+
+    ```python
+    transform = Cast(
+        {
+            "feature_a": pl.Boolean,
+            "feature_b": pl.Float64,
+        },
+    )
+    ```
+    """
 
     def __init__(
         self,

--- a/tests/polars/transforms/test_cast.py
+++ b/tests/polars/transforms/test_cast.py
@@ -53,6 +53,34 @@ class CastTransform(unittest.TestCase):
             ),
         )
 
+    def test_dictionary(self) -> None:
+        transform = Cast(
+            {
+                "a": pl.Boolean,
+                "b": pl.Float64,
+            },
+        )
+
+        data_frame = pl.DataFrame(
+            [
+                {"a": 1, "b": 2},
+                {"a": 0, "b": 4},
+                {"a": 1, "b": 6},
+            ],
+        ).lazy()
+        transformed_data = transform(data_frame).collect()
+
+        assert_frame_equal(
+            transformed_data,
+            pl.DataFrame(
+                [
+                    {"a": True, "b": 2.0},
+                    {"a": False, "b": 4.0},
+                    {"a": True, "b": 6.0},
+                ],
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR:
- Allows the `Cast` transform to take a dictionary argument of feature-name and target type to apply different casts to different features.
- Add a docstring to the transform.