### PR TITLE
Add Sliding Window for Timeseries

### DIFF
--- a/src/flowcean/polars/transforms/__init__.py
+++ b/src/flowcean/polars/transforms/__init__.py
@@ -17,6 +17,7 @@ from .resample import Resample
 from .select import Select
 from .signal_filter import SignalFilter, SignalFilterType
 from .sliding_window import SlidingWindow
+from .sliding_window_ts import TimeSeriesSlidingWindow
 from .standardize import Standardize
 from .time_window import TimeWindow
 from .to_time_series import ToTimeSeries
@@ -49,6 +50,7 @@ __all__ = [
     "SignalFilterType",
     "SlidingWindow",
     "Standardize",
+    "TimeSeriesSlidingWindow",
     "TimeWindow",
     "ToTimeSeries",
     "Unnest",

--- a/src/flowcean/polars/transforms/sliding_window_ts.py
+++ b/src/flowcean/polars/transforms/sliding_window_ts.py
@@ -1,0 +1,112 @@
+import logging
+from collections.abc import Iterable
+
+import polars as pl
+from typing_extensions import override
+
+from flowcean.core import Transform
+from flowcean.polars.is_time_series import is_timeseries_feature
+
+logger = logging.getLogger(__name__)
+
+
+class TimeSeriesSlidingWindow(Transform):
+    """Convert single large time series into a set of smaller sub-series.
+
+    Applies a sliding window to each individual time series sample of all or
+    selected time series features while leaving other features unchanged.
+    As a result, the resulting data frame will contain multiple samples for
+    each original sample, where each sample is a sub-series of the original
+    time series. The number of features (columns) will remain the same.
+    """
+
+    def __init__(
+        self,
+        window_size: int,
+        *,
+        features: str | Iterable[str] | None = None,
+        stride: int = 1,
+        rechunk: bool = True,
+    ) -> None:
+        """Initializes the TimeSeriesSlidingWindow transform.
+
+        Args:
+            window_size: The size of the sliding window.
+            features: The features to apply the sliding window to. If None, all
+                time series features are selected.
+            stride: The stride of the sliding window.
+            rechunk: Whether to rechunk the data after applying the transform.
+                Rechunking improves performance of subsequent operations, but
+                increases memory usage and may slow down the initial operation.
+        """
+        self.window_size = window_size
+        self.features = features
+        self.stride = stride
+        self.rechunk = rechunk
+
+    @override
+    def apply(self, data: pl.LazyFrame) -> pl.LazyFrame:
+        # Find the target features the rolling window should be applied to.
+        schema = data.collect_schema()
+        if self.features is None:
+            target_features = schema.names()
+        elif isinstance(self.features, str):
+            target_features = [self.features]
+        else:
+            target_features = list(self.features)
+
+        # We can only handle time series data.
+        target_features = [
+            feature
+            for feature in target_features
+            if is_timeseries_feature(schema, feature)
+        ]
+
+        return data.map_batches(
+            lambda df: self._map_frame(df, target_features=target_features),
+        )
+
+    def _map_frame(
+        self,
+        df: pl.DataFrame,
+        target_features: list[str],
+    ) -> pl.DataFrame:
+        result_df = pl.DataFrame(schema=df.schema)
+        all_features = df.schema.names()
+
+        for row in df.iter_rows(named=True):
+            # Find the length of the time series in the target features and
+            # check that they match.
+            ts_lengths = [len(row[feature]) for feature in target_features]
+            if len(set(ts_lengths)) != 1:
+                msg = "All time series features must have the same length."
+                raise ValueError(msg)
+
+            # Slice the time series features into windows, create a new row and
+            # append it to the result.
+            result_df = pl.concat(
+                [
+                    result_df,
+                    *[
+                        pl.DataFrame(
+                            [
+                                {
+                                    feature: (
+                                        row[feature][i : i + self.window_size]
+                                        if feature in target_features
+                                        else row[feature]
+                                    )
+                                    for feature in all_features
+                                },
+                            ],
+                            schema=df.schema,
+                        )
+                        for i in range(
+                            0,
+                            ts_lengths[0] - self.window_size + 1,
+                            self.stride,
+                        )
+                    ],
+                ],
+            )
+        return result_df.rechunk() if self.rechunk else result_df

--- a/src/flowcean/polars/transforms/sliding_window_ts.py
+++ b/src/flowcean/polars/transforms/sliding_window_ts.py
@@ -67,6 +67,8 @@ class TimeSeriesSlidingWindow(Transform):
 
         return data.map_batches(
             lambda df: self._map_frame(df, target_features=target_features),
+            slice_pushdown=False,
+            streamable=True,
         )
 
     def _map_frame(

--- a/src/flowcean/polars/transforms/sliding_window_ts.py
+++ b/src/flowcean/polars/transforms/sliding_window_ts.py
@@ -18,6 +18,9 @@ class TimeSeriesSlidingWindow(Transform):
     As a result, the resulting data frame will contain multiple samples for
     each original sample, where each sample is a sub-series of the original
     time series. The number of features (columns) will remain the same.
+    For this transform to work, all selected time series features of a sample
+    must have the same time vector. Use a `MatchSamplingRate` or `Resample`
+    transform to ensure this is the case.
     """
 
     def __init__(

--- a/tests/polars/transforms/test_sliding_window_ts.py
+++ b/tests/polars/transforms/test_sliding_window_ts.py
@@ -1,0 +1,153 @@
+import unittest
+
+import polars as pl
+from polars.testing import assert_frame_equal
+
+from flowcean.polars.transforms import TimeSeriesSlidingWindow
+
+
+class TimeSeriesSlidingWindowTransform(unittest.TestCase):
+    def test_single_ts(self) -> None:
+        dataset = pl.DataFrame(
+            {
+                "feature_a": [
+                    [
+                        {"time": 0, "value": 42},
+                        {"time": 1, "value": 43},
+                        {"time": 2, "value": 44},
+                    ],
+                    [
+                        {"time": 0, "value": 17},
+                        {"time": 1, "value": 16},
+                        {"time": 2, "value": 15},
+                    ],
+                ],
+            },
+        )
+
+        transform = TimeSeriesSlidingWindow(2)
+        transformed = transform.apply(dataset.lazy()).collect()
+
+        assert_frame_equal(
+            transformed,
+            pl.DataFrame(
+                {
+                    "feature_a": [
+                        [
+                            {"time": 0, "value": 42},
+                            {"time": 1, "value": 43},
+                        ],
+                        [
+                            {"time": 1, "value": 43},
+                            {"time": 2, "value": 44},
+                        ],
+                        [
+                            {"time": 0, "value": 17},
+                            {"time": 1, "value": 16},
+                        ],
+                        [
+                            {"time": 1, "value": 16},
+                            {"time": 2, "value": 15},
+                        ],
+                    ],
+                },
+            ),
+            check_column_order=False,
+        )
+
+    def test_multiple_features(self) -> None:
+        dataset = pl.DataFrame(
+            {
+                "feature_a": [
+                    [
+                        {"time": 0, "value": 42},
+                        {"time": 1, "value": 43},
+                        {"time": 2, "value": 44},
+                    ],
+                ],
+                "feature_b": [
+                    [
+                        {"time": 0, "value": 17},
+                        {"time": 1, "value": 16},
+                        {"time": 2, "value": 15},
+                    ],
+                ],
+                "feature_c": ["a"],
+            },
+        )
+
+        transform = TimeSeriesSlidingWindow(
+            2,
+            features=["feature_a", "feature_b"],
+        )
+        transformed = transform.apply(dataset.lazy()).collect()
+
+        assert_frame_equal(
+            transformed,
+            pl.DataFrame(
+                {
+                    "feature_a": [
+                        [
+                            {"time": 0, "value": 42},
+                            {"time": 1, "value": 43},
+                        ],
+                        [
+                            {"time": 1, "value": 43},
+                            {"time": 2, "value": 44},
+                        ],
+                    ],
+                    "feature_b": [
+                        [
+                            {"time": 0, "value": 17},
+                            {"time": 1, "value": 16},
+                        ],
+                        [
+                            {"time": 1, "value": 16},
+                            {"time": 2, "value": 15},
+                        ],
+                    ],
+                    "feature_c": ["a", "a"],
+                },
+            ),
+            check_column_order=False,
+        )
+
+    def test_stride(self) -> None:
+        dataset = pl.DataFrame(
+            {
+                "feature_a": [
+                    [
+                        {"time": 0, "value": 42},
+                        {"time": 1, "value": 43},
+                        {"time": 2, "value": 44},
+                        {"time": 3, "value": 45},
+                    ],
+                ],
+            },
+        )
+
+        transform = TimeSeriesSlidingWindow(2, stride=2)
+        transformed = transform.apply(dataset.lazy()).collect()
+
+        assert_frame_equal(
+            transformed,
+            pl.DataFrame(
+                {
+                    "feature_a": [
+                        [
+                            {"time": 0, "value": 42},
+                            {"time": 1, "value": 43},
+                        ],
+                        [
+                            {"time": 2, "value": 44},
+                            {"time": 3, "value": 45},
+                        ],
+                    ],
+                },
+            ),
+            check_column_order=False,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR:
- Adds a `TimeSeriesSlidingWindow` transform. This transform is not very efficient, but I think we would rather have an inefficient transform than none at all. But as I'm using `map_batches` this should be compatible with the streaming engine and does not require all data to be present in memory at the same time.

The transform could still use an example. I'll add one, once we agree on the generel functionality.