### PR TITLE
Use new Polars Streaming Engine

### DIFF
--- a/examples/automatic_lashing_platform/preload_alp_data.py
+++ b/examples/automatic_lashing_platform/preload_alp_data.py
@@ -1,7 +1,9 @@
 import logging
 import time
 from pathlib import Path
+from typing import cast
 
+import polars as pl
 from tqdm import tqdm
 
 import flowcean.cli
@@ -37,7 +39,9 @@ def main() -> None:
     time_end = time.time()
     logger.info("took %.5f s to load data", time_end - time_start)
 
-    data.observe().collect(streaming=True).write_parquet(
+    cast(pl.LazyFrame, data.observe()).collect(
+        engine="streaming",
+    ).write_parquet(
         Path("./alp_sim_data.parquet"),
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
   "joblib>=1.4.2",
   "lightning>=2.4.0",
   "numpy>=1.26.4",
-  "polars>=1.9.0",
+  "polars>=1.25.0",
   "protobuf>=5.28.2",
   "rosbags>=0.10.4",
   "ruamel-yaml>=0.18.6",
@@ -64,7 +64,7 @@ dev = [
   "ruff>=0.9.2",
 ]
 
-examples = ["matplotlib>=3.10.0", "opencv-python>=4.11.0.86",   "pillow>=11.1.0"]
+examples = ["matplotlib>=3.10.0", "opencv-python>=4.11.0.86", "pillow>=11.1.0"]
 
 [tool.uv.workspace]
 members = ["flowcean-sklearn", "flowcean-pytorch", "flowcean-ros", "flowcean-ode", "flowcean-grpc"]

--- a/src/flowcean/core/strategies/active.py
+++ b/src/flowcean/core/strategies/active.py
@@ -30,11 +30,11 @@ def learn_active(
     model = None
     try:
         while True:
-            observations = environment.observe().collect(streaming=True)
+            observations = environment.observe().collect(engine="streaming")
             action = learner.propose_action(observations)
             environment.act(action)
             environment.step()
-            observations = environment.observe().collect(streaming=True)
+            observations = environment.observe().collect(engine="streaming")
             model = learner.learn_active(action, observations)
     except StopLearning:
         pass

--- a/src/flowcean/polars/environments/datasetprediction.py
+++ b/src/flowcean/polars/environments/datasetprediction.py
@@ -47,13 +47,7 @@ class DatasetPredictionEnvironment(ActiveEnvironment):
             self.data = cast(pl.LazyFrame, self.environment.observe())
         self.i += self.batch_size
         self.slice = self.data.slice(self.i, self.batch_size)
-        if (
-            self.slice.slice(0, 1)
-            .collect(streaming=False)
-            .select(pl.len())
-            .item(0, 0)
-            == 0
-        ):
+        if self.slice.slice(0, 1).collect().select(pl.len()).item(0, 0) == 0:
             raise Finished
 
     @override

--- a/src/flowcean/polars/environments/streaming.py
+++ b/src/flowcean/polars/environments/streaming.py
@@ -47,11 +47,5 @@ class StreamingOfflineEnvironment(IncrementalEnvironment):
             self.data = cast(pl.LazyFrame, self.environment.observe())
         self.i += self.batch_size
         self.slice = self.data.slice(self.i, self.batch_size)
-        if (
-            self.slice.slice(0, 1)
-            .collect(streaming=False)
-            .select(pl.len())
-            .item(0, 0)
-            == 0
-        ):
+        if self.slice.slice(0, 1).collect().select(pl.len()).item(0, 0) == 0:
             raise Finished

--- a/src/flowcean/polars/environments/train_test_split.py
+++ b/src/flowcean/polars/environments/train_test_split.py
@@ -49,7 +49,7 @@ class TrainTestSplit:
             environment: The environment to split.
         """
         logger.info("Splitting data into train and test sets")
-        data = environment.observe().collect(streaming=True)
+        data = environment.observe().collect(engine="streaming")
         pivot = int(len(data) * self.ratio)
         splits = _split(
             data,

--- a/src/flowcean/polars/transforms/flatten.py
+++ b/src/flowcean/polars/transforms/flatten.py
@@ -66,7 +66,7 @@ class Flatten(Transform):
             row_lengths = (
                 data.select(pl.col(feature).list.len())
                 .unique()
-                .collect(streaming=True)
+                .collect(engine="streaming")
             )
 
             # Check if all rows have the same length

--- a/src/flowcean/polars/transforms/one_cold.py
+++ b/src/flowcean/polars/transforms/one_cold.py
@@ -132,7 +132,7 @@ class OneCold(Transform):
                         pl.all(),
                     ).all(),  # Combine the results for all data entries ...
                 )
-                .collect(streaming=True)
+                .collect(engine="streaming")
                 # ... and get the final result.
                 # If it is false, there is a missing category
                 .item(0, 0)

--- a/src/flowcean/polars/transforms/one_hot.py
+++ b/src/flowcean/polars/transforms/one_hot.py
@@ -102,7 +102,7 @@ class OneHot(Transform):
                     ],
                 )
                 .select(pl.any_horizontal(pl.all()).all())
-                .collect(streaming=True)
+                .collect(engine="streaming")
                 .item(0, 0)
             ):
                 raise NoMatchingCategoryError
@@ -144,7 +144,7 @@ class OneHot(Transform):
                 )
             feature_categories[feature] = (
                 data.select(pl.col(feature).unique())
-                .collect(streaming=True)
+                .collect(engine="streaming")
                 .to_series()
                 .to_list()
             )

--- a/src/flowcean/polars/transforms/standardize.py
+++ b/src/flowcean/polars/transforms/standardize.py
@@ -33,7 +33,7 @@ class Standardize(Transform, FitOnce):
 
     @override
     def fit(self, data: pl.LazyFrame) -> None:
-        df = data.collect(streaming=True)
+        df = data.collect(engine="streaming")
 
         self.mean = {
             c: _as_float(df[c].mean()) for c in data.collect_schema().names()

--- a/src/flowcean/sklearn/metrics/classification.py
+++ b/src/flowcean/sklearn/metrics/classification.py
@@ -16,8 +16,8 @@ class Accuracy(OfflineMetric):
     @override
     def __call__(self, true: pl.LazyFrame, predicted: pl.LazyFrame) -> Any:
         return metrics.accuracy_score(
-            true.collect(streaming=True),
-            predicted.collect(streaming=True),
+            true.collect(engine="streaming"),
+            predicted.collect(engine="streaming"),
         )
 
 
@@ -30,8 +30,8 @@ class ClassificationReport(OfflineMetric):
     @override
     def __call__(self, true: pl.LazyFrame, predicted: pl.LazyFrame) -> Any:
         return metrics.classification_report(
-            true.collect(streaming=True),
-            predicted.collect(streaming=True),
+            true.collect(engine="streaming"),
+            predicted.collect(engine="streaming"),
         )
 
 
@@ -52,8 +52,8 @@ class FBetaScore(OfflineMetric):
     @override
     def __call__(self, true: pl.LazyFrame, predicted: pl.LazyFrame) -> Any:
         return metrics.fbeta_score(
-            true.collect(streaming=True),
-            predicted.collect(streaming=True),
+            true.collect(engine="streaming"),
+            predicted.collect(engine="streaming"),
             beta=self.beta,
         )
 
@@ -67,8 +67,8 @@ class PrecisionScore(OfflineMetric):
     @override
     def __call__(self, true: pl.LazyFrame, predicted: pl.LazyFrame) -> Any:
         return metrics.precision_score(
-            true.collect(streaming=True),
-            predicted.collect(streaming=True),
+            true.collect(engine="streaming"),
+            predicted.collect(engine="streaming"),
         )
 
 
@@ -81,6 +81,6 @@ class Recall(OfflineMetric):
     @override
     def __call__(self, true: pl.LazyFrame, predicted: pl.LazyFrame) -> Any:
         return metrics.recall_score(
-            true.collect(streaming=True),
-            predicted.collect(streaming=True),
+            true.collect(engine="streaming"),
+            predicted.collect(engine="streaming"),
         )

--- a/src/flowcean/sklearn/metrics/regression.py
+++ b/src/flowcean/sklearn/metrics/regression.py
@@ -16,8 +16,8 @@ class MaxError(OfflineMetric):
     @override
     def __call__(self, true: pl.LazyFrame, predicted: pl.LazyFrame) -> Any:
         return metrics.max_error(
-            true.collect(streaming=True),
-            predicted.collect(streaming=True),
+            true.collect(engine="streaming"),
+            predicted.collect(engine="streaming"),
         )
 
 
@@ -30,8 +30,8 @@ class MeanAbsoluteError(OfflineMetric):
     @override
     def __call__(self, true: pl.LazyFrame, predicted: pl.LazyFrame) -> Any:
         return metrics.mean_absolute_error(
-            true.collect(streaming=True),
-            predicted.collect(streaming=True),
+            true.collect(engine="streaming"),
+            predicted.collect(engine="streaming"),
         )
 
 
@@ -44,8 +44,8 @@ class MeanSquaredError(OfflineMetric):
     @override
     def __call__(self, true: pl.LazyFrame, predicted: pl.LazyFrame) -> Any:
         return metrics.mean_squared_error(
-            true.collect(streaming=True),
-            predicted.collect(streaming=True),
+            true.collect(engine="streaming"),
+            predicted.collect(engine="streaming"),
         )
 
 
@@ -58,6 +58,6 @@ class R2Score(OfflineMetric):
     @override
     def __call__(self, true: pl.LazyFrame, predicted: pl.LazyFrame) -> Any:
         return metrics.r2_score(
-            true.collect(streaming=True),
-            predicted.collect(streaming=True),
+            true.collect(engine="streaming"),
+            predicted.collect(engine="streaming"),
         )

--- a/uv.lock
+++ b/uv.lock
@@ -1112,7 +1112,7 @@ requires-dist = [
     { name = "joblib", specifier = ">=1.4.2" },
     { name = "lightning", specifier = ">=2.4.0" },
     { name = "numpy", specifier = ">=1.26.4" },
-    { name = "polars", specifier = ">=1.9.0" },
+    { name = "polars", specifier = ">=1.25.0" },
     { name = "protobuf", specifier = ">=5.28.2" },
     { name = "rosbags", specifier = ">=0.10.4" },
     { name = "ruamel-yaml", specifier = ">=0.18.6" },
@@ -2207,7 +2207,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.1.0.70"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/fd/713452cd72343f682b1c7b9321e23829f00b842ceaedcda96e742ea0b0b3/nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl", hash = "sha256:165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f", size = 664752741 },
@@ -2218,7 +2218,7 @@ name = "nvidia-cufft-cu12"
 version = "11.2.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/94/3266821f65b92b3138631e9c8e7fe1fb513804ac934485a8d05776e1dd43/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f083fc24912aa410be21fa16d157fed2055dab1cc4b6934a0e03cba69eb242b9", size = 211459117 },
@@ -2237,9 +2237,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.6.1.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/e1/5b9089a4b2a4790dfdea8b3a006052cfecff58139d5a4e34cb1a51df8d6f/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl", hash = "sha256:19e33fa442bcfd085b3086c4ebf7e8debc07cfe01e11513cc6d332fd918ac260", size = 127936057 },
@@ -2250,7 +2250,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.3.1.170"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/f7/97a9ea26ed4bbbfc2d470994b8b4f338ef663be97b8f677519ac195e113d/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ea4f11a2904e2a8dc4b1833cc1b5181cde564edd0d5cd33e3c168eff2d1863f1", size = 207454763 },
@@ -2492,16 +2492,16 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.24.0"
+version = "1.25.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/d3/453bcecbe14a5aba6be47c99d81f4e1f941d3de729d5e0ce5c7d527c05ed/polars-1.24.0.tar.gz", hash = "sha256:6e7553789495081c998f5e4ad4ebc7e19e970a9cc83326d40461564e85ad226d", size = 4446066 }
+sdist = { url = "https://files.pythonhosted.org/packages/57/56/d8a13c3a1990c92cc2c4f1887e97ea15aabf5685b1e826f875ca3e4e6c9e/polars-1.25.2.tar.gz", hash = "sha256:c6bd9b1b17c86e49bcf8aac44d2238b77e414d7df890afc3924812a5c989a4fe", size = 4501858 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/3f/16f87d9ec4707d717a434bc54307506594522de99fdfe3d5d76233912c94/polars-1.24.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:563b99a6597fe77a3c89d478e4a6fb49c063f44ef84d4adefe490e14626e2f99", size = 33792674 },
-    { url = "https://files.pythonhosted.org/packages/35/cd/27353d0b9331d60a95f5708370441348d4a3af0f609961ceaaa3b583190f/polars-1.24.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:6ad64d938d60b7fda39b60892ef67bc6a9942e0c7170db593a65d019e8730b09", size = 30469541 },
-    { url = "https://files.pythonhosted.org/packages/a7/db/668d8328b1c3d8381023fc4ed905a88b93cca041c088f42a94dbd6822469/polars-1.24.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:331e737465b8d954bec51e6906bdc6e979a6ee52f97ffe5e8d0c10794a46bfd9", size = 34313540 },
-    { url = "https://files.pythonhosted.org/packages/12/16/f95207616b2e802c381459cf01f0d233daa98bdc4e394ec88044af9e927f/polars-1.24.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:3c6c774aebdd5cd601839594986648789352f72b8893f4b7e34224e75b060c8d", size = 31490266 },
-    { url = "https://files.pythonhosted.org/packages/8b/82/cb0512747ec5508a4f840a521feb27f28a81eac1aef6c92fc25643073579/polars-1.24.0-cp39-abi3-win_amd64.whl", hash = "sha256:a5a473ff44fe1b9e3e7a9013a9321efe841d858e89cf33d424e6f3fef3ea4d5e", size = 34678593 },
-    { url = "https://files.pythonhosted.org/packages/67/00/db3810803938467a215c1f161ff21ad6fef581d5ac1381ee2990d0180c19/polars-1.24.0-cp39-abi3-win_arm64.whl", hash = "sha256:5ea781ca8e0a39c3b677171dbd852e5fa2d5c53417b5fbd69d711b6044a49eaa", size = 30892251 },
+    { url = "https://files.pythonhosted.org/packages/bd/ec/61ae653b7848769baa5c5aaa00f3b3eaedaec56c3f1203a90dafe893a368/polars-1.25.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:59f2a34520ea4307a22e18b832310f8045a8a348606ca99ae785499b31eb4170", size = 34539929 },
+    { url = "https://files.pythonhosted.org/packages/58/80/54f8cbb048558114ca519d7c40a994130c5a537246923ecce47cf269eaa6/polars-1.25.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e9fe45bdc2327c2e2b64e8849a992b6d3bd4a7e7848b8a7a3a439cca9674dc87", size = 31326982 },
+    { url = "https://files.pythonhosted.org/packages/cd/92/db411b7c83f694dca1b8348fa57a120c27c67cf622b85fa88c7ecf463adb/polars-1.25.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7fcbb4f476784384ccda48757fca4e8c2e2c5a0a3aef3717aaf56aee4e30e09", size = 35121263 },
+    { url = "https://files.pythonhosted.org/packages/9f/a5/5ff200ce3bc643d5f12d91eddb9720fa083267c45fe395bcf0046e97cc2d/polars-1.25.2-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:9dd91885c9ee5ffad8725c8591f73fb7bd2632c740277ee641f0453176b3d4b8", size = 32254697 },
+    { url = "https://files.pythonhosted.org/packages/70/d5/7a5458d05d5a0af816b1c7034aa1d026b7b8176a8de41e96dac70fcf29e2/polars-1.25.2-cp39-abi3-win_amd64.whl", hash = "sha256:a547796643b9a56cb2959be87d7cb87ff80a5c8ae9367f32fe1ad717039e9afc", size = 35318381 },
+    { url = "https://files.pythonhosted.org/packages/24/df/60d35c4ae8ec357a5fb9914eb253bd1bad9e0f5332eda2bd2c6371dd3668/polars-1.25.2-cp39-abi3-win_arm64.whl", hash = "sha256:a2488e9d4b67bf47b18088f7264999180559e6ec2637ed11f9d0d4f98a74a37c", size = 31619833 },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR:
- Increases the minimum `polars` version to `1.25` to use the new streaming engine.
- Change all `LazyFrame.collect` to use the new `engine` parameter.

Supersedes #251.