### PR TITLE
Removed rules removed from ruff

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -13,8 +13,6 @@ preview = false
 select = ["ALL"]
 ignore = [
   "A005",    # module shadows standard library imports
-  "ANN101",  # deprecated
-  "ANN102",  # deprecated
   "ANN401",  # dynamically typed expressions (typing.Any) are disallowed
   "ERA001",  # commented-out code
   "D10",     # missing docstrings


### PR DESCRIPTION
This PR:
- Removes two rules which were previously ignored but are now removed from `ruff` entirley - so ignoring them no longer has any effect.