### PR TITLE
Expose activation function as argument for MLPs

### DIFF
--- a/examples/one_tank/run.py
+++ b/examples/one_tank/run.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 import numpy as np
 import polars as pl
+import torch
 from numpy.typing import NDArray
 from typing_extensions import Self, override
 
@@ -129,6 +130,7 @@ def main() -> None:
                 input_size=len(inputs),
                 output_size=len(outputs),
                 hidden_dimensions=[10, 10],
+                activation_function=torch.nn.Tanh,
             ),
             max_epochs=10,
         ),

--- a/src/flowcean/torch/lightning_learner.py
+++ b/src/flowcean/torch/lightning_learner.py
@@ -78,6 +78,8 @@ class MultilayerPerceptron(lightning.LightningModule):
         input_size: int,
         output_size: int,
         hidden_dimensions: list[int] | None = None,
+        *,
+        activation_function: type[torch.nn.Module] | None = None,
     ) -> None:
         """Initialize the model.
 
@@ -86,6 +88,8 @@ class MultilayerPerceptron(lightning.LightningModule):
             input_size: The size of the input.
             output_size: The size of the output.
             hidden_dimensions: The dimensions of the hidden layers.
+            activation_function: The activation function to use.
+                Defaults to ReLU if not provided.
         """
         super().__init__()
         if hidden_dimensions is None:
@@ -99,7 +103,9 @@ class MultilayerPerceptron(lightning.LightningModule):
             layers.extend(
                 (
                     torch.nn.Linear(hidden_size, dimension),
-                    torch.nn.LeakyReLU(),
+                    activation_function()
+                    if activation_function
+                    else torch.nn.ReLU(),
                 ),
             )
             hidden_size = dimension


### PR DESCRIPTION
This PR:
- Exposes the `activation_function` as an optional parameter when training an MLP.