### PR TITLE
Fix Polars List Eval

### DIFF
--- a/src/flowcean/polars/transforms/resample.py
+++ b/src/flowcean/polars/transforms/resample.py
@@ -54,10 +54,10 @@ class Resample(Transform):
             data = data.with_columns(
                 pl.struct(
                     pl.col(feature)
-                    .list.eval(pl.first().struct.field("time"))
+                    .list.eval(pl.element().struct.field("time"))
                     .alias("time"),
                     pl.col(feature)
-                    .list.eval(pl.first().struct.field("value"))
+                    .list.eval(pl.element().struct.field("value"))
                     .alias("value"),
                 )
                 .map_elements(

--- a/src/flowcean/polars/transforms/signal_filter.py
+++ b/src/flowcean/polars/transforms/signal_filter.py
@@ -51,10 +51,10 @@ class SignalFilter(Transform):
             data = data.with_columns(
                 pl.struct(
                     pl.col(feature)
-                    .list.eval(pl.first().struct.field("time"))
+                    .list.eval(pl.element().struct.field("time"))
                     .alias("time"),
                     pl.col(feature)
-                    .list.eval(pl.first().struct.field("value"))
+                    .list.eval(pl.element().struct.field("value"))
                     .alias("value"),
                 )
                 .map_elements(

--- a/tests/polars/transforms/test_signal_filter.py
+++ b/tests/polars/transforms/test_signal_filter.py
@@ -41,7 +41,7 @@ class SignalFilterTransform(unittest.TestCase):
         transformed_values = (
             transformed_values.select(
                 pl.col("feature_a").list.eval(
-                    pl.first().struct.field("value"),
+                    pl.element().struct.field("value"),
                 ),
             )
             .item()
@@ -92,7 +92,7 @@ class SignalFilterTransform(unittest.TestCase):
         transformed_values = (
             transformed_values.select(
                 pl.col("feature_a").list.eval(
-                    pl.first().struct.field("value"),
+                    pl.element().struct.field("value"),
                 ),
             )
             .item()


### PR DESCRIPTION
This PR replaces all `pl.first` in `pl.list.eval` with `pl.element`. The former is outdated and raises and error with the latest polars version.