### PR TITLE
Use `collect_all` instead of two separate collects

### DIFF
--- a/src/flowcean/grpc/learner.py
+++ b/src/flowcean/grpc/learner.py
@@ -189,9 +189,10 @@ class GrpcPassiveAutomataLearner(SupervisedLearner, Model):
         inputs: pl.LazyFrame,
         outputs: pl.LazyFrame,
     ) -> GrpcPassiveAutomataLearner:
+        dfs = pl.collect_all([inputs, outputs])
         proto_datapackage = DataPackage(
-            inputs=[_row_to_proto(row) for row in inputs.collect().rows()],
-            outputs=[_row_to_proto(row) for row in outputs.collect().rows()],
+            inputs=[_row_to_proto(row) for row in dfs[0].rows()],
+            outputs=[_row_to_proto(row) for row in dfs[1].rows()],
         )
         stream = self._stub.Train(  # type: ignore[type]
             proto_datapackage,

--- a/src/flowcean/sklearn/regression_tree.py
+++ b/src/flowcean/sklearn/regression_tree.py
@@ -47,8 +47,9 @@ class RegressionTree(SupervisedLearner):
         inputs: pl.LazyFrame,
         outputs: pl.LazyFrame,
     ) -> Model:
-        collected_inputs = inputs.collect()
-        collected_outputs = outputs.collect()
+        dfs = pl.collect_all([inputs, outputs])
+        collected_inputs = dfs[0]
+        collected_outputs = dfs[1]
         self.regressor.fit(collected_inputs, collected_outputs)
         if self.dot_graph_export_path is not None:
             logger.info(

--- a/src/flowcean/torch/lightning_learner.py
+++ b/src/flowcean/torch/lightning_learner.py
@@ -53,8 +53,9 @@ class LightningLearner(SupervisedLearner):
         inputs: pl.LazyFrame,
         outputs: pl.LazyFrame,
     ) -> PyTorchModel:
-        collected_inputs = inputs.collect()
-        collected_outputs = outputs.collect()
+        dfs = pl.collect_all([inputs, outputs])
+        collected_inputs = dfs[0]
+        collected_outputs = dfs[1]
         dataset = TorchDataset(collected_inputs, collected_outputs)
         dataloader = DataLoader(
             dataset,

--- a/src/flowcean/torch/linear_regression.py
+++ b/src/flowcean/torch/linear_regression.py
@@ -41,8 +41,9 @@ class LinearRegression(SupervisedIncrementalLearner):
         outputs: pl.LazyFrame,
     ) -> PyTorchModel:
         self.optimizer.zero_grad()
-        features = torch.from_numpy(inputs.collect().to_numpy(writable=True))
-        labels = torch.from_numpy(outputs.collect().to_numpy(writable=True))
+        dfs = pl.collect_all([inputs, outputs])
+        features = torch.from_numpy(dfs[0].to_numpy(writable=True))
+        labels = torch.from_numpy(dfs[1].to_numpy(writable=True))
         prediction = self.model(features)
         loss = self.loss(prediction, labels)
         loss.backward()


### PR DESCRIPTION
This MR:
- Replaces some `collect` calls with `pl.collect_all`. The later allows polars to apply optimizations to the whole query and reuse cached results. Those changes could potentially speed up learning by a good amount.