### PR TITLE
Fix OPC Adapter Pre-Recording

### DIFF
--- a/src/flowcean/adapter/opc/adapter.py
+++ b/src/flowcean/adapter/opc/adapter.py
@@ -270,6 +270,7 @@ class OPCAdapter(Adapter):
 
             # Record a sample of data
             results = self.client.get_values(self.input_features.values())
+            now = datetime.now(tz=timezone.utc)
             self.recorded_data = pl.concat(
                 [
                     self.recorded_data,
@@ -278,7 +279,7 @@ class OPCAdapter(Adapter):
                         schema=self.input_schema,
                         orient="row",
                     ).with_columns(
-                        _recorded_time=pl.lit(datetime.now(timezone.utc)).cast(
+                        _recorded_time=pl.lit(now).cast(
                             pl.Datetime,
                         ),
                     ),
@@ -293,7 +294,7 @@ class OPCAdapter(Adapter):
                 # Discard old data that is older than `capture_time`.
                 self.recorded_data = self.recorded_data.filter(
                     pl.col("_recorded_time")
-                    >= pl.lit(datetime.now(timezone.utc)).cast(pl.Datetime)
+                    >= pl.lit(now).cast(pl.Datetime)
                     - self.pre_capture_window_length,
                 )
             else:

--- a/src/flowcean/adapter/opc/adapter.py
+++ b/src/flowcean/adapter/opc/adapter.py
@@ -288,7 +288,7 @@ class OPCAdapter(Adapter):
             # Check if we are still pre-recording
             if self.streaming_handler.is_streaming():
                 prerecording_in_progress = False
-            else:
+            elif prerecording_in_progress:
                 # Still pre-recording
                 # Discard old data that is older than `capture_time`.
                 self.recorded_data = self.recorded_data.filter(
@@ -296,6 +296,9 @@ class OPCAdapter(Adapter):
                     >= pl.lit(datetime.now(timezone.utc)).cast(pl.Datetime)
                     - self.pre_capture_window_length,
                 )
+            else:
+                # Done with pre-recording and streaming
+                return False
 
             return True
 

--- a/src/flowcean/adapter/opc/adapter.py
+++ b/src/flowcean/adapter/opc/adapter.py
@@ -160,6 +160,10 @@ class OPCAdapter(Adapter):
         self.client.connect()
         self.client.load_type_definitions()
 
+        # Set the log level of the opcua library to WARNING to reduce
+        # verbosity
+        logging.getLogger("opcua").setLevel(logging.WARNING)
+
         # Start a keep-alive mechanism to ensure the connection stays alive
         self.client.keepalive = KeepAlive(
             self.client,


### PR DESCRIPTION
This PR:
- Fixes the pre-recording in the OPC Adapter. With the previous implementation the adapter briefly switched back to "pre-recording" after recording was done, dropping all values beside the last two seconds.
- Reduces the log level of the opc-ua library.