### PR TITLE
Track Input Features for Regression Trees

### DIFF
--- a/src/flowcean/sklearn/regression_tree.py
+++ b/src/flowcean/sklearn/regression_tree.py
@@ -80,4 +80,5 @@ class RegressionTree(SupervisedLearner):
         return SciKitModel(
             self.regressor,
             output_names=collected_outputs.columns,
+            input_names=collected_inputs.columns,
         )


### PR DESCRIPTION
This PR:
- Adds additional tracking of the input feature names for the regression tree. Without this change the regression tree rejects observation with too many features, even if all required features are present.