### PR TITLE
Add threshold support for classifier models

### DIFF
--- a/src/flowcean/core/__init__.py
+++ b/src/flowcean/core/__init__.py
@@ -22,7 +22,7 @@ from .learner import (
     SupervisedLearner,
 )
 from .metric import Metric
-from .model import Model
+from .model import ClassifierModel, Model
 from .report import Report, Reportable
 from .strategies.active import (
     Action,
@@ -33,7 +33,7 @@ from .strategies.active import (
 )
 from .strategies.deploy import deploy
 from .strategies.incremental import learn_incremental
-from .strategies.offline import evaluate_offline, learn_offline
+from .strategies.offline import evaluate_offline, learn_offline, tune_threshold
 from .transform import (
     ChainedTransforms,
     Identity,
@@ -54,6 +54,7 @@ __all__ = [
     "CallbackMixin",
     "ChainedOfflineEnvironments",
     "ChainedTransforms",
+    "ClassifierModel",
     "Data",
     "Environment",
     "Finished",
@@ -85,4 +86,5 @@ __all__ = [
     "learn_active",
     "learn_incremental",
     "learn_offline",
+    "tune_threshold",
 ]

--- a/src/flowcean/core/model.py
+++ b/src/flowcean/core/model.py
@@ -17,22 +17,10 @@ class Model(Named, Protocol):
     """Base class for models.
 
     A model is used to predict outputs for given inputs.
-
-    Optional Protocol Extensions:
-        For classification models that support probability predictions and
-        custom thresholds:
-        - Implement `_predict_proba` method to return class probabilities
-        - Implement `predict_proba` method (with preprocessing)
-        - Set `threshold` attribute to customize the decision boundary
-
-        Note: These are optional extensions. Models that don't implement
-        them (e.g., regressors) will work normally. Type checkers may show
-        warnings, but the code will work correctly at runtime.
     """
 
     pre_transform: Transform = Identity()
     post_transform: Transform = Identity()
-    threshold: float | None = None
 
     def preprocess(self, input_features: Data) -> Data:
         """Preprocess pipeline step."""
@@ -123,3 +111,26 @@ class Model(Named, Protocol):
             instance = pickle.load(file)
 
         return instance
+
+
+@runtime_checkable
+class ClassifierModel(Model, Protocol):
+    """Protocol for classifier models with threshold-based predictions.
+
+    Extends Model with probability predictions and a configurable decision
+    threshold. Implement this protocol for classifiers that support
+    ``predict_proba``.
+    """
+
+    threshold: float
+
+    def predict_proba(self, input_features: Data) -> Data:
+        """Predict class probabilities.
+
+        Args:
+            input_features: The inputs for which to predict probabilities.
+
+        Returns:
+            The predicted probabilities for the positive class.
+        """
+        ...

--- a/src/flowcean/core/model.py
+++ b/src/flowcean/core/model.py
@@ -16,12 +16,23 @@ if TYPE_CHECKING:
 class Model(Named, Protocol):
     """Base class for models.
 
-    A model represents learned patterns extracted by a learner from data.
-    It is used to predict outputs for given inputs.
+    A model is used to predict outputs for given inputs.
+
+    Optional Protocol Extensions:
+        For classification models that support probability predictions and
+        custom thresholds:
+        - Implement `_predict_proba` method to return class probabilities
+        - Implement `predict_proba` method (with preprocessing)
+        - Set `threshold` attribute to customize the decision boundary
+
+        Note: These are optional extensions. Models that don't implement
+        them (e.g., regressors) will work normally. Type checkers may show
+        warnings, but the code will work correctly at runtime.
     """
 
     pre_transform: Transform = Identity()
     post_transform: Transform = Identity()
+    threshold: float | None = None
 
     def preprocess(self, input_features: Data) -> Data:
         """Preprocess pipeline step."""

--- a/src/flowcean/core/strategies/offline.py
+++ b/src/flowcean/core/strategies/offline.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Sequence
 from flowcean.core.environment.offline import OfflineEnvironment
 from flowcean.core.learner import SupervisedLearner
 from flowcean.core.metric import Metric
-from flowcean.core.model import Model
+from flowcean.core.model import ClassifierModel, Model
 from flowcean.core.report import Report, ReportEntry
 from flowcean.core.transform import Identity, InvertibleTransform, Transform
 
@@ -108,7 +108,7 @@ def evaluate_offline(
 
 
 def tune_threshold(
-    model: Model,
+    model: ClassifierModel,
     environment: OfflineEnvironment,
     inputs: Sequence[str],
     outputs: Sequence[str],
@@ -120,12 +120,10 @@ def tune_threshold(
     """Find optimal decision threshold for a classifier.
 
     Evaluates the model at multiple threshold values and returns the threshold
-    that maximizes the given metric. Only works with models that support
-    probability predictions (i.e., have a threshold attribute and
-    predict_proba method).
+    that maximizes the given metric.
 
     Args:
-        model: The classifier model to tune. Must have a threshold attribute.
+        model: The classifier model to tune.
         environment: The offline environment with validation/test data.
         inputs: The input feature names.
         outputs: The output feature names.
@@ -139,10 +137,6 @@ def tune_threshold(
         Tuple of (best_threshold, results_dict) where results_dict maps
         each threshold to its metric score.
 
-    Raises:
-        AttributeError: If model does not have a threshold attribute.
-        ValueError: If model does not support probability predictions.
-
     Example:
         >>> from flowcean.sklearn.metrics.classification import FBetaScore
         >>> metric = FBetaScore(beta=1.0)
@@ -153,21 +147,6 @@ def tune_threshold(
         >>> model.threshold = best_threshold  # Apply the best threshold
     """
     import numpy as np
-
-    # Check if model supports thresholds
-    if not hasattr(model, "threshold"):
-        msg = (
-            f"Model {model.__class__.__name__} does not have a threshold "
-            "attribute. Only classifier models support threshold tuning."
-        )
-        raise AttributeError(msg)
-
-    if not hasattr(model, "predict_proba"):
-        msg = (
-            f"Model {model.__class__.__name__} does not implement "
-            "predict_proba. Threshold tuning requires probability predictions."
-        )
-        raise ValueError(msg)
 
     # Generate thresholds if not provided
     thresholds_to_test: Sequence[float]
@@ -244,12 +223,5 @@ def tune_threshold(
     finally:
         # Restore original threshold
         model.threshold = original_threshold
-
-    logger.info(
-        "Best threshold: %.3f with %s = %.4f",
-        best_threshold,
-        metric.name,
-        best_score,
-    )
 
     return best_threshold, results

--- a/src/flowcean/core/strategies/offline.py
+++ b/src/flowcean/core/strategies/offline.py
@@ -146,11 +146,11 @@ def tune_threshold(
     Example:
         >>> from flowcean.sklearn.metrics.classification import FBetaScore
         >>> metric = FBetaScore(beta=1.0)
-        >>> best_thr, results = tune_threshold(
+        >>> best_threshold, results = tune_threshold(
         ...     model, eval_env, inputs, outputs, metric
         ... )
-        >>> print(f"Best threshold: {best_thr:.3f}")
-        >>> model.threshold = best_thr  # Apply the best threshold
+        >>> print(f"Best threshold: {best_threshold:.3f}")
+        >>> model.threshold = best_threshold  # Apply the best threshold
     """
     import numpy as np
 

--- a/src/flowcean/core/strategies/offline.py
+++ b/src/flowcean/core/strategies/offline.py
@@ -105,3 +105,151 @@ def evaluate_offline(
             },
         )
     return Report(entries)
+
+
+def tune_threshold(
+    model: Model,
+    environment: OfflineEnvironment,
+    inputs: Sequence[str],
+    outputs: Sequence[str],
+    metric: Metric,
+    *,
+    thresholds: Sequence[float] | None = None,
+    num_thresholds: int = 19,
+) -> tuple[float, dict[float, float]]:
+    """Find optimal decision threshold for a classifier.
+
+    Evaluates the model at multiple threshold values and returns the threshold
+    that maximizes the given metric. Only works with models that support
+    probability predictions (i.e., have a threshold attribute and
+    predict_proba method).
+
+    Args:
+        model: The classifier model to tune. Must have a threshold attribute.
+        environment: The offline environment with validation/test data.
+        inputs: The input feature names.
+        outputs: The output feature names.
+        metric: The metric to optimize (e.g., FBetaScore, Accuracy).
+        thresholds: Specific thresholds to evaluate. If None, generates
+            num_thresholds evenly spaced values between 0.05 and 0.95.
+        num_thresholds: Number of thresholds to evaluate if thresholds is
+            None (default: 19).
+
+    Returns:
+        Tuple of (best_threshold, results_dict) where results_dict maps
+        each threshold to its metric score.
+
+    Raises:
+        AttributeError: If model does not have a threshold attribute.
+        ValueError: If model does not support probability predictions.
+
+    Example:
+        >>> from flowcean.sklearn.metrics.classification import FBetaScore
+        >>> metric = FBetaScore(beta=1.0)
+        >>> best_thr, results = tune_threshold(
+        ...     model, eval_env, inputs, outputs, metric
+        ... )
+        >>> print(f"Best threshold: {best_thr:.3f}")
+        >>> model.threshold = best_thr  # Apply the best threshold
+    """
+    import numpy as np
+
+    # Check if model supports thresholds
+    if not hasattr(model, "threshold"):
+        msg = (
+            f"Model {model.__class__.__name__} does not have a threshold "
+            "attribute. Only classifier models support threshold tuning."
+        )
+        raise AttributeError(msg)
+
+    if not hasattr(model, "predict_proba"):
+        msg = (
+            f"Model {model.__class__.__name__} does not implement "
+            "predict_proba. Threshold tuning requires probability predictions."
+        )
+        raise ValueError(msg)
+
+    # Generate thresholds if not provided
+    thresholds_to_test: Sequence[float]
+    if thresholds is None:
+        thresholds_to_test = list(np.linspace(0.05, 0.95, num_thresholds))
+    else:
+        thresholds_to_test = thresholds
+
+    # Store original threshold
+    original_threshold = model.threshold
+
+    # Evaluate at each threshold
+    results: dict[float, float] = {}
+    best_threshold = 0.5
+    best_score = -float("inf")
+
+    logger.info(
+        "Tuning threshold for %s using %s",
+        model.name,
+        metric.name,
+    )
+
+    try:
+        for threshold in thresholds_to_test:
+            # Set threshold and evaluate
+            model.threshold = float(threshold)
+            report = evaluate_offline(
+                model,
+                environment,
+                inputs,
+                outputs,
+                [metric],
+            )
+
+            # Extract metric score from report
+            # Report is dict[str, ReportEntry]
+            # ReportEntry is dict[str, Reportable]
+            model_entry = report.get(model.name)
+            if model_entry is None:
+                continue
+
+            score_value = model_entry.get(metric.name)
+            if score_value is None:
+                continue
+
+            # Convert Reportable to float (it should be a numeric value)
+            if isinstance(score_value, (int, float)):
+                score = float(score_value)
+            else:
+                # Try to convert via string representation
+                try:
+                    score = float(str(score_value))
+                except (ValueError, TypeError):
+                    logger.warning(
+                        "Could not convert metric value to float: %s",
+                        score_value,
+                    )
+                    continue
+
+            results[float(threshold)] = score
+
+            # Track best threshold
+            if score > best_score:
+                best_score = score
+                best_threshold = float(threshold)
+
+            logger.debug(
+                "Threshold %.3f: %s = %.4f",
+                threshold,
+                metric.name,
+                score,
+            )
+
+    finally:
+        # Restore original threshold
+        model.threshold = original_threshold
+
+    logger.info(
+        "Best threshold: %.3f with %s = %.4f",
+        best_threshold,
+        metric.name,
+        best_score,
+    )
+
+    return best_threshold, results

--- a/src/flowcean/sklearn/__init__.py
+++ b/src/flowcean/sklearn/__init__.py
@@ -13,7 +13,7 @@ from .metrics.regression import (
     MeanSquaredError,
     R2Score,
 )
-from .model import SciKitModel
+from .model import SciKitClassifierModel, SciKitModel
 from .random_forest import RandomForestRegressorLearner
 from .regression_tree import RegressionTree
 
@@ -31,5 +31,6 @@ __all__ = [
     "RandomForestRegressorLearner",
     "Recall",
     "RegressionTree",
+    "SciKitClassifierModel",
     "SciKitModel",
 ]

--- a/src/flowcean/sklearn/adaboost_classifier.py
+++ b/src/flowcean/sklearn/adaboost_classifier.py
@@ -29,6 +29,7 @@ class AdaBoost(SupervisedLearner):
         learning_rate: float = 1.0,
         algorithm: str = "deprecated",
         random_state: int | None = None,
+        threshold: float | None = None,
     ) -> None:
         """Initialize the AdaBoost classifier learner.
 
@@ -41,6 +42,7 @@ class AdaBoost(SupervisedLearner):
             algorithm=algorithm,
             random_state=random_state or get_seed(),
         )
+        self.threshold = threshold
 
     @override
     def learn(
@@ -74,4 +76,5 @@ class AdaBoost(SupervisedLearner):
         return SciKitModel(
             self.classifier,
             output_names=[collected_outputs.columns[0]],
+            threshold=self.threshold,
         )

--- a/src/flowcean/sklearn/adaboost_classifier.py
+++ b/src/flowcean/sklearn/adaboost_classifier.py
@@ -8,7 +8,7 @@ from typing_extensions import override
 from flowcean.core import Model, SupervisedLearner
 from flowcean.utils import get_seed
 
-from .model import SciKitModel
+from .model import SciKitClassifierModel
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class AdaBoost(SupervisedLearner):
         learning_rate: float = 1.0,
         algorithm: str = "deprecated",
         random_state: int | None = None,
-        threshold: float | None = None,
+        threshold: float = 0.5,
     ) -> None:
         """Initialize the AdaBoost classifier learner.
 
@@ -73,7 +73,7 @@ class AdaBoost(SupervisedLearner):
             )
 
         self.classifier.fit(x, y)
-        return SciKitModel(
+        return SciKitClassifierModel(
             self.classifier,
             output_names=[collected_outputs.columns[0]],
             threshold=self.threshold,

--- a/src/flowcean/sklearn/model.py
+++ b/src/flowcean/sklearn/model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import polars as pl
 from typing_extensions import override
@@ -78,7 +78,9 @@ class SciKitModel(Model):
             )
             raise AttributeError(msg)
 
-        probas = self.estimator.predict_proba(input_features)[:, 1]
+        # Cast to SupportsPredictProba for type checker
+        estimator = cast("SupportsPredictProba", self.estimator)
+        probas = estimator.predict_proba(input_features)[:, 1]
 
         if len(self.output_names) == 1:
             data = {self.output_names[0]: probas}
@@ -117,7 +119,8 @@ class SciKitModel(Model):
         # Use threshold-based prediction if threshold is set and
         # model supports it
         if self.threshold is not None and hasattr(
-            self.estimator, "predict_proba",
+            self.estimator,
+            "predict_proba",
         ):
             probas = self._predict_proba(input_features).collect()
             predictions = {}

--- a/src/flowcean/sklearn/model.py
+++ b/src/flowcean/sklearn/model.py
@@ -28,8 +28,9 @@ class SupportsPredictProba(Protocol):
 class SciKitModel(Model):
     """A model that wraps a scikit-learn model.
 
-    For classifiers with predict_proba, this model supports threshold-based
-    predictions. Set the threshold attribute to customize the decision boundary.
+    For classifiers with predict_proba, this model supports
+    threshold-based predictions. Set the threshold attribute to
+    customize the decision boundary.
     """
 
     estimator: SupportsPredict
@@ -48,9 +49,10 @@ class SciKitModel(Model):
         Args:
             estimator: The scikit-learn estimator.
             output_names: The names of the output columns.
-            threshold: Optional decision threshold for classifiers (default: None).
-                If set and estimator has predict_proba, uses threshold-based
-                prediction. Otherwise uses estimator's default predict method.
+            threshold: Optional decision threshold for classifiers
+                (default: None). If set and estimator has predict_proba,
+                uses threshold-based prediction. Otherwise uses
+                estimator's default predict method.
             name: The name of the model.
         """
         super().__init__()
@@ -112,10 +114,10 @@ class SciKitModel(Model):
         if isinstance(input_features, pl.LazyFrame):
             input_features = input_features.collect()
 
-        # Use threshold-based prediction if threshold is set and model supports it
-        if (
-            self.threshold is not None
-            and hasattr(self.estimator, "predict_proba")
+        # Use threshold-based prediction if threshold is set and
+        # model supports it
+        if self.threshold is not None and hasattr(
+            self.estimator, "predict_proba",
         ):
             probas = self._predict_proba(input_features).collect()
             predictions = {}

--- a/src/flowcean/sklearn/model.py
+++ b/src/flowcean/sklearn/model.py
@@ -16,11 +16,21 @@ if TYPE_CHECKING:
 class SupportsPredict(Protocol):
     """Protocol describing an object that has a `predict` method."""
 
-    def predict(self, X: Any) -> NDArray: ...  # noqa: N803 X is a standard name in sklearn
+    def predict(self, X: Any) -> NDArray: ...  # noqa: N803
+
+
+class SupportsPredictProba(Protocol):
+    """Protocol describing an object that has a `predict_proba` method."""
+
+    def predict_proba(self, X: Any) -> NDArray: ...  # noqa: N803
 
 
 class SciKitModel(Model):
-    """A model that wraps a scikit-learn model."""
+    """A model that wraps a scikit-learn model.
+
+    For classifiers with predict_proba, this model supports threshold-based
+    predictions. Set the threshold attribute to customize the decision boundary.
+    """
 
     estimator: SupportsPredict
     output_names: list[str]
@@ -30,6 +40,7 @@ class SciKitModel(Model):
         estimator: SupportsPredict,
         *,
         output_names: Iterable[str],
+        threshold: float | None = None,
         name: str | None = None,
     ) -> None:
         """Initialize the model.
@@ -37,13 +48,61 @@ class SciKitModel(Model):
         Args:
             estimator: The scikit-learn estimator.
             output_names: The names of the output columns.
+            threshold: Optional decision threshold for classifiers (default: None).
+                If set and estimator has predict_proba, uses threshold-based
+                prediction. Otherwise uses estimator's default predict method.
             name: The name of the model.
         """
+        super().__init__()
         if name is None:
             name = estimator.__class__.__name__
         self._name = name
         self.estimator = estimator
         self.output_names = list(output_names)
+        self.threshold = threshold
+
+    def _predict_proba(
+        self,
+        input_features: pl.DataFrame | pl.LazyFrame,
+    ) -> pl.LazyFrame:
+        """Predict class probabilities (only for classifiers)."""
+        if isinstance(input_features, pl.LazyFrame):
+            input_features = input_features.collect()
+
+        if not hasattr(self.estimator, "predict_proba"):
+            msg = (
+                f"Estimator {self.estimator.__class__.__name__} "
+                "does not support predict_proba"
+            )
+            raise AttributeError(msg)
+
+        probas = self.estimator.predict_proba(input_features)[:, 1]
+
+        if len(self.output_names) == 1:
+            data = {self.output_names[0]: probas}
+        else:
+            data = {
+                self.output_names[i]: probas[:, i]
+                for i in range(len(self.output_names))
+            }
+        return pl.LazyFrame(data)
+
+    def predict_proba(
+        self,
+        input_features: pl.DataFrame | pl.LazyFrame,
+    ) -> pl.LazyFrame:
+        """Predict class probabilities, applying preprocessing transforms.
+
+        Only available for classifiers that implement predict_proba.
+
+        Args:
+            input_features: The inputs for which to predict probabilities.
+
+        Returns:
+            The predicted probabilities for the positive class.
+        """
+        input_features = self.preprocess(input_features)
+        return self._predict_proba(input_features)
 
     @override
     def _predict(
@@ -53,6 +112,20 @@ class SciKitModel(Model):
         if isinstance(input_features, pl.LazyFrame):
             input_features = input_features.collect()
 
+        # Use threshold-based prediction if threshold is set and model supports it
+        if (
+            self.threshold is not None
+            and hasattr(self.estimator, "predict_proba")
+        ):
+            probas = self._predict_proba(input_features).collect()
+            predictions = {}
+            for col in probas.columns:
+                predictions[col] = (probas[col] >= self.threshold).cast(
+                    pl.Int64,
+                )
+            return pl.LazyFrame(predictions)
+
+        # Otherwise use default predict
         outputs = self.estimator.predict(input_features)
         if len(self.output_names) == 1:
             data = {self.output_names[0]: outputs}

--- a/src/flowcean/sklearn/model.py
+++ b/src/flowcean/sklearn/model.py
@@ -26,12 +26,7 @@ class SupportsPredictProba(Protocol):
 
 
 class SciKitModel(Model):
-    """A model that wraps a scikit-learn model.
-
-    For classifiers with predict_proba, this model supports
-    threshold-based predictions. Set the threshold attribute to
-    customize the decision boundary.
-    """
+    """A model that wraps a scikit-learn estimator."""
 
     estimator: SupportsPredict
     output_names: list[str]
@@ -41,7 +36,6 @@ class SciKitModel(Model):
         estimator: SupportsPredict,
         *,
         output_names: Iterable[str],
-        threshold: float | None = None,
         name: str | None = None,
     ) -> None:
         """Initialize the model.
@@ -49,10 +43,6 @@ class SciKitModel(Model):
         Args:
             estimator: The scikit-learn estimator.
             output_names: The names of the output columns.
-            threshold: Optional decision threshold for classifiers
-                (default: None). If set and estimator has predict_proba,
-                uses threshold-based prediction. Otherwise uses
-                estimator's default predict method.
             name: The name of the model.
         """
         super().__init__()
@@ -61,24 +51,65 @@ class SciKitModel(Model):
         self._name = name
         self.estimator = estimator
         self.output_names = list(output_names)
+
+    @override
+    def _predict(
+        self,
+        input_features: pl.DataFrame | pl.LazyFrame,
+    ) -> pl.LazyFrame:
+        if isinstance(input_features, pl.LazyFrame):
+            input_features = input_features.collect()
+
+        outputs = self.estimator.predict(input_features)
+        if len(self.output_names) == 1:
+            data = {self.output_names[0]: outputs}
+        else:
+            data = {
+                self.output_names[i]: outputs[:, i]
+                for i in range(len(self.output_names))
+            }
+        return pl.LazyFrame(data)
+
+
+class SciKitClassifierModel(SciKitModel):
+    """A SciKit model for classifiers with probability predictions.
+
+    Supports threshold-based predictions via the ``threshold`` attribute and
+    exposes class probabilities via ``predict_proba``. The estimator must
+    implement ``predict_proba``.
+    """
+
+    threshold: float
+
+    def __init__(
+        self,
+        estimator: SupportsPredict,
+        *,
+        output_names: Iterable[str],
+        threshold: float = 0.5,
+        name: str | None = None,
+    ) -> None:
+        """Initialize the classifier model.
+
+        Args:
+            estimator: The scikit-learn classifier (must support
+                ``predict_proba``).
+            output_names: The names of the output columns.
+            threshold: Decision threshold for the positive class
+                (default: 0.5).
+            name: The name of the model.
+        """
+        super().__init__(estimator, output_names=output_names, name=name)
         self.threshold = threshold
 
     def _predict_proba(
         self,
         input_features: pl.DataFrame | pl.LazyFrame,
     ) -> pl.LazyFrame:
-        """Predict class probabilities (only for classifiers)."""
+        """Predict class probabilities (without preprocessing)."""
         if isinstance(input_features, pl.LazyFrame):
             input_features = input_features.collect()
 
-        if not hasattr(self.estimator, "predict_proba"):
-            msg = (
-                f"Estimator {self.estimator.__class__.__name__} "
-                "does not support predict_proba"
-            )
-            raise AttributeError(msg)
-
-        # Cast to SupportsPredictProba for type checker
         estimator = cast("SupportsPredictProba", self.estimator)
         probas = estimator.predict_proba(input_features)[:, 1]
 
@@ -97,8 +128,6 @@ class SciKitModel(Model):
     ) -> pl.LazyFrame:
         """Predict class probabilities, applying preprocessing transforms.
 
-        Only available for classifiers that implement predict_proba.
-
         Args:
             input_features: The inputs for which to predict probabilities.
 
@@ -116,27 +145,8 @@ class SciKitModel(Model):
         if isinstance(input_features, pl.LazyFrame):
             input_features = input_features.collect()
 
-        # Use threshold-based prediction if threshold is set and
-        # model supports it
-        if self.threshold is not None and hasattr(
-            self.estimator,
-            "predict_proba",
-        ):
-            probas = self._predict_proba(input_features).collect()
-            predictions = {}
-            for col in probas.columns:
-                predictions[col] = (probas[col] >= self.threshold).cast(
-                    pl.Int64,
-                )
-            return pl.LazyFrame(predictions)
-
-        # Otherwise use default predict
-        outputs = self.estimator.predict(input_features)
-        if len(self.output_names) == 1:
-            data = {self.output_names[0]: outputs}
-        else:
-            data = {
-                self.output_names[i]: outputs[:, i]
-                for i in range(len(self.output_names))
-            }
-        return pl.LazyFrame(data)
+        probas = self._predict_proba(input_features).collect()
+        predictions = {}
+        for col in probas.columns:
+            predictions[col] = (probas[col] >= self.threshold).cast(pl.Int64)
+        return pl.LazyFrame(predictions)

--- a/src/flowcean/xgboost/learner.py
+++ b/src/flowcean/xgboost/learner.py
@@ -2,11 +2,72 @@ from typing import Any
 
 import polars as pl
 from xgboost import XGBClassifier, XGBRegressor
+from xgboost.callback import TrainingCallback
 
 from flowcean.core import LearnerCallback, create_callback_manager
 from flowcean.core.learner import SupervisedLearner
+from flowcean.core.named import Named
 
 from .model import XGBoostClassifierModel, XGBoostRegressorModel
+
+
+class XGBoostCallbackBridge(TrainingCallback):
+    """Bridge between XGBoost callbacks and flowcean callbacks.
+
+    This adapter forwards XGBoost training events to flowcean callbacks.
+    """
+
+    def __init__(
+        self,
+        learner: Named,
+        callback_manager: Any,
+        max_iterations: int | None = None,
+    ) -> None:
+        self.learner = learner
+        self.callback_manager = callback_manager
+        self.max_iterations = max_iterations
+
+    def before_training(self, model: Any) -> Any:
+        """Called before training starts."""
+        # XGBoost callbacks don't get called at the very beginning,
+        # so we'll call on_learning_start from the learn method instead
+        return model
+
+    def after_iteration(
+        self,
+        model: Any,  # noqa: ARG002
+        epoch: int,
+        evals_log: dict[str, Any],
+    ) -> bool:
+        """Called after each training iteration."""
+        # Calculate progress if we know the max iterations
+        progress = None
+        if self.max_iterations and self.max_iterations > 0:
+            progress = (epoch + 1) / self.max_iterations
+
+        # Extract metrics from evals_log if available
+        metrics = {"iteration": epoch + 1}
+        if evals_log:
+            # Flatten the nested evals_log structure
+            for dataset_name, dataset_metrics in evals_log.items():
+                for metric_name, values in dataset_metrics.items():
+                    if values:
+                        metrics[f"{dataset_name}_{metric_name}"] = values[-1]
+
+        self.callback_manager.on_learning_progress(
+            self.learner,
+            progress=progress,
+            metrics=metrics,
+        )
+
+        # Return False to continue training
+        return False
+
+    def after_training(self, model: Any) -> Any:
+        """Called after training completes."""
+        # We'll call on_learning_end from the learn method instead
+        # to have access to the wrapped model
+        return model
 
 
 class XGBoostClassifierLearner(SupervisedLearner):
@@ -14,10 +75,18 @@ class XGBoostClassifierLearner(SupervisedLearner):
 
     Args:
         threshold: Decision threshold for binary classification (default: 0.5).
-        **kwargs: Additional arguments passed to XGBClassifier.
+        callbacks: Optional callbacks for progress feedback. Use `None` for
+            silent learning.
+        **kwargs: Arguments passed to XGBClassifier
+            (n_estimators, max_depth, etc.)
     """
 
-    def __init__(self, threshold: float = 0.5, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        threshold: float = 0.5,
+        callbacks: list[LearnerCallback] | LearnerCallback | None = None,
+        **kwargs: Any,
+    ) -> None:
         self.threshold = threshold
         self.classifier = XGBClassifier(**kwargs)
         self.callback_manager = create_callback_manager(callbacks)
@@ -34,17 +103,50 @@ class XGBoostClassifierLearner(SupervisedLearner):
         inputs_collected = dfs[0]
         outputs_collected = dfs[1]
 
-        # Fit the classifier
-        self.classifier.fit(
-            inputs_collected.to_numpy(),
-            outputs_collected.to_numpy(),
-        )
-        return XGBoostClassifierModel(
-            self.classifier,
-            input_features=inputs_collected.columns,
-            output_features=outputs_collected.columns,
-            threshold=self.threshold,
-        )
+        # Notify callbacks that learning is starting
+        context = {
+            "n_estimators": self.classifier.n_estimators,
+            "n_samples": len(inputs_collected),
+            "n_features": len(inputs_collected.columns),
+        }
+        self.callback_manager.on_learning_start(self, context)
+
+        try:
+            # Create bridge callback for XGBoost
+            xgb_callback = XGBoostCallbackBridge(
+                learner=self,
+                callback_manager=self.callback_manager,
+                max_iterations=self.classifier.n_estimators,
+            )
+
+            # In XGBoost 3.0+, callbacks must be set on the model, not in fit()
+            # Get current params and recreate classifier with callbacks
+            params = self.classifier.get_params()
+            params["callbacks"] = [xgb_callback]
+            self.classifier = XGBClassifier(**params)
+
+            # Fit the classifier
+            self.classifier.fit(
+                inputs_collected.to_numpy(),
+                outputs_collected.to_numpy(),
+            )
+
+            # Create the model
+            model = XGBoostClassifierModel(
+                self.classifier,
+                input_features=inputs_collected.columns,
+                output_features=outputs_collected.columns,
+                threshold=self.threshold,
+            )
+
+            # Notify callbacks that learning is complete
+            self.callback_manager.on_learning_end(self, model)
+        except Exception as e:
+            # Notify callbacks of the error
+            self.callback_manager.on_learning_error(self, e)
+            raise
+        else:
+            return model
 
 
 class XGBoostRegressorLearner(SupervisedLearner):

--- a/src/flowcean/xgboost/learner.py
+++ b/src/flowcean/xgboost/learner.py
@@ -2,89 +2,24 @@ from typing import Any
 
 import polars as pl
 from xgboost import XGBClassifier, XGBRegressor
-from xgboost.callback import TrainingCallback
 
 from flowcean.core import LearnerCallback, create_callback_manager
 from flowcean.core.learner import SupervisedLearner
-from flowcean.core.named import Named
 
 from .model import XGBoostClassifierModel, XGBoostRegressorModel
-
-
-class XGBoostCallbackBridge(TrainingCallback):
-    """Bridge between XGBoost callbacks and flowcean callbacks.
-
-    This adapter forwards XGBoost training events to flowcean callbacks.
-    """
-
-    def __init__(
-        self,
-        learner: Named,
-        callback_manager: Any,
-        max_iterations: int | None = None,
-    ) -> None:
-        self.learner = learner
-        self.callback_manager = callback_manager
-        self.max_iterations = max_iterations
-
-    def before_training(self, model: Any) -> Any:
-        """Called before training starts."""
-        # XGBoost callbacks don't get called at the very beginning,
-        # so we'll call on_learning_start from the learn method instead
-        return model
-
-    def after_iteration(
-        self,
-        model: Any,  # noqa: ARG002
-        epoch: int,
-        evals_log: dict[str, Any],
-    ) -> bool:
-        """Called after each training iteration."""
-        # Calculate progress if we know the max iterations
-        progress = None
-        if self.max_iterations and self.max_iterations > 0:
-            progress = (epoch + 1) / self.max_iterations
-
-        # Extract metrics from evals_log if available
-        metrics = {"iteration": epoch + 1}
-        if evals_log:
-            # Flatten the nested evals_log structure
-            for dataset_name, dataset_metrics in evals_log.items():
-                for metric_name, values in dataset_metrics.items():
-                    if values:
-                        metrics[f"{dataset_name}_{metric_name}"] = values[-1]
-
-        self.callback_manager.on_learning_progress(
-            self.learner,
-            progress=progress,
-            metrics=metrics,
-        )
-
-        # Return False to continue training
-        return False
-
-    def after_training(self, model: Any) -> Any:
-        """Called after training completes."""
-        # We'll call on_learning_end from the learn method instead
-        # to have access to the wrapped model
-        return model
 
 
 class XGBoostClassifierLearner(SupervisedLearner):
     """Wrapper for XGBoost classifiers.
 
     Args:
-        callbacks: Optional callbacks for progress feedback. Use `None` for
-            silent learning.
-        **kwargs: Arguments passed to XGBClassifier
-            (n_estimators, max_depth, etc.)
+        threshold: Decision threshold for binary classification (default: 0.5).
+        **kwargs: Additional arguments passed to XGBClassifier.
     """
 
-    def __init__(
-        self,
-        callbacks: list[LearnerCallback] | LearnerCallback | None = None,
-        **kwargs: Any,
-    ) -> None:
+    def __init__(self, threshold: float = 0.5, **kwargs: Any) -> None:
+        # Store threshold separately - don't pass to XGBoost
+        self.threshold = threshold
         self.classifier = XGBClassifier(**kwargs)
         self.callback_manager = create_callback_manager(callbacks)
         super().__init__()
@@ -100,49 +35,17 @@ class XGBoostClassifierLearner(SupervisedLearner):
         inputs_collected = dfs[0]
         outputs_collected = dfs[1]
 
-        # Notify callbacks that learning is starting
-        context = {
-            "n_estimators": self.classifier.n_estimators,
-            "n_samples": len(inputs_collected),
-            "n_features": len(inputs_collected.columns),
-        }
-        self.callback_manager.on_learning_start(self, context)
-
-        try:
-            # Create bridge callback for XGBoost
-            xgb_callback = XGBoostCallbackBridge(
-                learner=self,
-                callback_manager=self.callback_manager,
-                max_iterations=self.classifier.n_estimators,
-            )
-
-            # In XGBoost 3.0+, callbacks must be set on the model, not in fit()
-            # Get current params and recreate classifier with callbacks
-            params = self.classifier.get_params()
-            params["callbacks"] = [xgb_callback]
-            self.classifier = XGBClassifier(**params)
-
-            # Fit the classifier
-            self.classifier.fit(
-                inputs_collected.to_numpy(),
-                outputs_collected.to_numpy(),
-            )
-
-            # Create the model
-            model = XGBoostClassifierModel(
-                self.classifier,
-                input_features=inputs_collected.columns,
-                output_features=outputs_collected.columns,
-            )
-
-            # Notify callbacks that learning is complete
-            self.callback_manager.on_learning_end(self, model)
-        except Exception as e:
-            # Notify callbacks of the error
-            self.callback_manager.on_learning_error(self, e)
-            raise
-        else:
-            return model
+        # Fit the classifier
+        self.classifier.fit(
+            inputs_collected.to_numpy(),
+            outputs_collected.to_numpy(),
+        )
+        return XGBoostClassifierModel(
+            self.classifier,
+            input_features=inputs_collected.columns,
+            output_features=outputs_collected.columns,
+            threshold=self.threshold,
+        )
 
 
 class XGBoostRegressorLearner(SupervisedLearner):

--- a/src/flowcean/xgboost/learner.py
+++ b/src/flowcean/xgboost/learner.py
@@ -18,7 +18,6 @@ class XGBoostClassifierLearner(SupervisedLearner):
     """
 
     def __init__(self, threshold: float = 0.5, **kwargs: Any) -> None:
-        # Store threshold separately - don't pass to XGBoost
         self.threshold = threshold
         self.classifier = XGBClassifier(**kwargs)
         self.callback_manager = create_callback_manager(callbacks)

--- a/src/flowcean/xgboost/model.py
+++ b/src/flowcean/xgboost/model.py
@@ -3,10 +3,11 @@ from typing_extensions import override
 from xgboost import XGBClassifier, XGBRegressor
 
 from flowcean.core.model import Model
+from flowcean.core.transform import Identity
 
 
 class XGBoostClassifierModel(Model):
-    """Wrapper for an XGBoost classifier model."""
+    """Wrapper for an XGBoost classifier model with threshold support."""
 
     classifier: XGBClassifier
 
@@ -19,11 +20,41 @@ class XGBoostClassifierModel(Model):
         *,
         input_features: list[str],
         output_features: list[str],
+        threshold: float = 0.5,
     ) -> None:
-        super().__init__()
         self.classifier = classifier
         self.input_features = input_features
         self.output_features = output_features
+        self.threshold = threshold
+        # Initialize Protocol attributes
+        self.pre_transform = Identity()
+        self.post_transform = Identity()
+
+    def _predict_proba(
+        self,
+        input_features: pl.LazyFrame,
+    ) -> pl.LazyFrame:
+        """Predict probability of positive class."""
+        proba = self.classifier.predict_proba(
+            input_features.select(self.input_features).collect().to_numpy(),
+        )[:, 1]  # Get positive class probability
+
+        return pl.from_numpy(
+            proba,
+            self.output_features,
+        ).lazy()
+
+    def predict_proba(self, input_features: pl.LazyFrame) -> pl.LazyFrame:
+        """Predict class probabilities, applying preprocessing transforms.
+
+        Args:
+            input_features: The inputs for which to predict probabilities.
+
+        Returns:
+            The predicted probabilities for the positive class.
+        """
+        input_features = self.preprocess(input_features)
+        return self._predict_proba(input_features)
 
     def __getstate__(self) -> dict:
         """Remove callbacks when pickling (they contain unpickleable locks)."""
@@ -51,6 +82,18 @@ class XGBoostClassifierModel(Model):
         self,
         input_features: pl.LazyFrame,
     ) -> pl.LazyFrame:
+        """Predict class labels using threshold."""
+        if self.threshold is not None:
+            # Use threshold-based prediction
+            probas = self._predict_proba(input_features).collect()
+            predictions = {}
+            for col in probas.columns:
+                predictions[col] = (probas[col] >= self.threshold).cast(
+                    pl.Int64,
+                )
+            return pl.LazyFrame(predictions)
+
+        # Use default prediction
         return pl.from_numpy(
             self.classifier.predict(
                 input_features.select(self.input_features)

--- a/src/flowcean/xgboost/model.py
+++ b/src/flowcean/xgboost/model.py
@@ -59,18 +59,13 @@ class XGBoostClassifierModel(Model):
     def __getstate__(self) -> dict:
         """Remove callbacks when pickling (they contain unpickleable locks)."""
         state = self.__dict__.copy()
-        # Remove callbacks from the classifier before pickling
         if "classifier" in state:
-            classifier = state["classifier"]
-            params = classifier.get_params()
-            if "callbacks" in params:
-                # Create a new classifier without callbacks
-                params_without_callbacks = {
-                    k: v for k, v in params.items() if k != "callbacks"
-                }
-                state["classifier"] = XGBClassifier(**params_without_callbacks)
-                # Copy trained model (need _Booster for pickling)
-                state["classifier"]._Booster = classifier._Booster  # noqa: SLF001
+            # Copy the full fitted state and null out callbacks only
+            classifier_dict = state["classifier"].__dict__.copy()
+            classifier_dict["callbacks"] = None
+            new_classifier = XGBClassifier.__new__(XGBClassifier)
+            new_classifier.__dict__.update(classifier_dict)
+            state["classifier"] = new_classifier
         return state
 
     def __setstate__(self, state: dict) -> None:
@@ -127,18 +122,13 @@ class XGBoostRegressorModel(Model):
     def __getstate__(self) -> dict:
         """Remove callbacks when pickling (they contain unpickleable locks)."""
         state = self.__dict__.copy()
-        # Remove callbacks from the regressor before pickling
         if "regressor" in state:
-            regressor = state["regressor"]
-            params = regressor.get_params()
-            if "callbacks" in params:
-                # Create a new regressor without callbacks
-                params_without_callbacks = {
-                    k: v for k, v in params.items() if k != "callbacks"
-                }
-                state["regressor"] = XGBRegressor(**params_without_callbacks)
-                # Copy trained model (need _Booster for pickling)
-                state["regressor"]._Booster = regressor._Booster  # noqa: SLF001
+            # Copy the full fitted state and null out callbacks only
+            regressor_dict = state["regressor"].__dict__.copy()
+            regressor_dict["callbacks"] = None
+            new_regressor = XGBRegressor.__new__(XGBRegressor)
+            new_regressor.__dict__.update(regressor_dict)
+            state["regressor"] = new_regressor
         return state
 
     def __setstate__(self, state: dict) -> None:


### PR DESCRIPTION
This PR adds configurable decision threshold support to Flowcean's classifier models, enabling users to optimize the precision-recall tradeoff without retraining models.

Classifiers now support:
- Custom decision thresholds, which can be set at training time or adjusted after training is done
- Probability predictions using predict_proba() method for all classifiers
- Automatic threshold tuning to find optimal threshold for any metric

Usage Examples
```
# Train with custom threshold
learner = XGBoostClassifierLearner(threshold=0.3)  # Favor recall
model = learn_offline(data, learner, inputs, outputs)

# Change threshold after training
model.threshold = 0.7  # Favor precision

# Get probability predictions
probabilities = model.predict_proba(test_data)

# Automatically find optimal threshold
from flowcean.sklearn.metrics.classification import FBetaScore

best_threshold, results = tune_threshold(
    model, 
    validation_data, 
    inputs, 
    outputs, 
    metric=FBetaScore(beta=1.0)
)
model.threshold = best_threshold
```