### PR TITLE
Allow module specific logging configuration

### DIFF
--- a/src/flowcean/cli/config.py
+++ b/src/flowcean/cli/config.py
@@ -31,8 +31,10 @@ def _load_config(path: Path) -> DictConfig | ListConfig:
 
 DEFAULT_CONFIG = {
     "logging": {
-        "level": "INFO",
-        "format": "%(asctime)s [%(name)s][%(levelname)s] %(message)s",
+        "root": {
+            "level": "INFO",
+            "format": "%(asctime)s [%(name)s][%(levelname)s] %(message)s",
+        },
     },
 }
 
@@ -78,5 +80,10 @@ def initialize(**kwargs: Any) -> DictConfig | ListConfig:
         The initialized configuration object.
     """
     conf = load_experiment_config(**kwargs)
-    logging.basicConfig(**conf.logging)
+    logging.basicConfig(**conf.logging.root)
+    for logger_name, logger_conf in conf.logging.items():
+        if logger_name == "root":
+            continue
+        logger = logging.getLogger(logger_name)
+        logger.setLevel(logger_conf.level)
     return conf


### PR DESCRIPTION
Allow setting logging levels for each module/scope individually

```sh
uv run foo.by logging.root.level=DEBUG
```
